### PR TITLE
fixed wolfgang launch files

### DIFF
--- a/wolfgang_description/launch/wolfgang_rviz.launch
+++ b/wolfgang_description/launch/wolfgang_rviz.launch
@@ -1,17 +1,6 @@
 <launch>
-  <arg name="gui" default="true" />
-
-  <include file="$(find bitbots_bringup)/launch/load_robot_description.launch">
-        <arg name="wolfgang" value="true"/>        
-  </include>
-
-  <param name="use_gui" value="$(arg gui)" />
-
-  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-
   <node name="rviz" pkg="rviz" type="rviz" output="screen" required="true"
       args="-d $(find wolfgang_description)/config/wolfgang.rviz" >
   </node>
-
 
 </launch>

--- a/wolfgang_description/launch/wolfgang_standalone.launch
+++ b/wolfgang_description/launch/wolfgang_standalone.launch
@@ -3,6 +3,9 @@
   <include file="$(find wolfgang_description)/launch/wolfgang_rviz.launch">        
   </include>
 
+    <include file="$(find bitbots_bringup)/launch/load_robot_description.launch">
+    </include>
+
   <!-- We do not have a robot connected, so publish fake joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
     <param name="/use_gui" value="true"/>


### PR DESCRIPTION
PR which should fix https://github.com/bit-bots/wolfgang_robot/issues/6
rviz launch only launches rviz with the wolfgang config
standalone launches the fake controller to have the robot in rviz and to play around with the model