### PR TITLE
moveit_config: remove attempts from kinematics.yaml

### DIFF
--- a/wolfgang_moveit_config/config/kinematics.yaml
+++ b/wolfgang_moveit_config/config/kinematics.yaml
@@ -2,27 +2,22 @@ LeftLeg:
   kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 0.0001
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1
   mode: gd_c
 RightLeg:
   kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 0.0001
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1
   mode: gd_c
 Legs:
   kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 1e-05
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1
   mode: gd_c
 All:
   kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 0.0001
   kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 1
 Head:
   kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 0.001
   kinematics_solver_timeout: 0.001
-  kinematics_solver_attempts: 2


### PR DESCRIPTION
They are now unsupported by kinematics solvers, a warning is issued when the parameter exists.