### PR TITLE
moveit_config: disable collisions between head and torso

### DIFF
--- a/wolfgang_moveit_config/config/wolfgang.srdf
+++ b/wolfgang_moveit_config/config/wolfgang.srdf
@@ -183,4 +183,5 @@
     <disable_collisions link1="r_shoulder" link2="torso" reason="Adjacent" />
     <disable_collisions link1="r_upper_arm" link2="r_upper_leg" reason="Never" />
     <disable_collisions link1="head" link2="neck" reason="Adjacent" />
+    <disable_collisions link1="head" link2="torso" reason="Adjacent" />
 </robot>


### PR DESCRIPTION
The head visual model was reintroduced in #17. This pull request disables collision between head and torso to make collision detection possible in the dynamic kick.