### PR TITLE
animations: remove pause in falling animations

### DIFF
--- a/wolfgang_animations/animations/falling/falling_back.json
+++ b/wolfgang_animations/animations/falling/falling_back.json
@@ -28,7 +28,7 @@
                 "RShoulderRoll": 0
             }, 
             "name": "walkready", 
-            "pause": 2.0
+            "pause": 0.0
         }
     ], 
     "last_edited": "2018-06-08 14:35:29.436275", 

--- a/wolfgang_animations/animations/falling/falling_front.json
+++ b/wolfgang_animations/animations/falling/falling_front.json
@@ -28,7 +28,7 @@
                 "RShoulderRoll": 0
             }, 
             "name": "frame0", 
-            "pause": 0.5,
+            "pause": 0.0,
             "torque": {
                 "HeadPan": 2, 
                 "HeadTilt": 2, 

--- a/wolfgang_animations/animations/falling/falling_left.json
+++ b/wolfgang_animations/animations/falling/falling_left.json
@@ -28,7 +28,7 @@
                 "RShoulderRoll": 0
             }, 
             "name": "generated frame", 
-            "pause": 1.0, 
+            "pause": 0.0, 
             "torque": {
                 "HeadPan": 2, 
                 "HeadTilt": 2, 

--- a/wolfgang_animations/animations/falling/falling_right.json
+++ b/wolfgang_animations/animations/falling/falling_right.json
@@ -28,7 +28,7 @@
                 "RShoulderRoll": 0
             }, 
             "name": "generated frame", 
-            "pause": 1.0, 
+            "pause": 0.0, 
             "torque": {
                 "HeadPan": 2, 
                 "HeadTilt": 2, 

--- a/wolfgang_animations/package.xml
+++ b/wolfgang_animations/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>wolfgang_animations</name>
-  <version>0.0.0</version>
+  <version>1.0.1</version>
   <description>Animation files for the wolfgang robot</description>
 
   <maintainer email="6stelter@informatik.uni-hamburg.de">Sebastian Stelter</maintainer>


### PR DESCRIPTION
## Proposed changes
As mentioned in bit-bots/bitbots_motion#98, this pull request removes the pause after the falling animations.

## Necessary checks
- [x] Update package version
- [ ] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
