### PR TITLE
add pause after falling_front

### DIFF
--- a/wolfgang_animations/animations/falling/falling_front.json
+++ b/wolfgang_animations/animations/falling/falling_front.json
@@ -28,7 +28,7 @@
                 "RShoulderRoll": 0
             }, 
             "name": "frame0", 
-            "pause": 0.0,
+            "pause": 0.1,
             "torque": {
                 "HeadPan": 2, 
                 "HeadTilt": 2, 

--- a/wolfgang_animations/package.xml
+++ b/wolfgang_animations/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>wolfgang_animations</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Animation files for the wolfgang robot</description>
 
   <maintainer email="6stelter@informatik.uni-hamburg.de">Sebastian Stelter</maintainer>


### PR DESCRIPTION
## Proposed changes
The falling animation is not fully executed without the pause at the end. Therefore, this PR adds a brief pause of 0.1 seconds after the animation.

## Necessary checks
- [x] Update package version
- [ ] ~~Run linters~~
- [ ] ~~Run `catkin build`~~
- [ ] ~~Write documentation~~
- [ ] ~~Test on your machine~~
- [x] Test on the robot

