### PR TITLE
remove double enabling of bibots docs causing docs to fail to build

### DIFF
--- a/wolfgang_webots_sim/CMakeLists.txt
+++ b/wolfgang_webots_sim/CMakeLists.txt
@@ -18,4 +18,3 @@ enable_bitbots_docs()
 
 catkin_package()
 
-enable_bitbots_docs()


### PR DESCRIPTION
## Proposed changes
Docs fail to build before this PR because documentation is built twice

## Necessary checks
- [x] Run `catkin build`
- [x] Test on your machine
- ~[ ] Test on the robot~
- [x] Put the PR on our Project board

