### PR TITLE
webots: fix duplicate publishing of joint positions

### DIFF
--- a/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_controller.py
+++ b/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_controller.py
@@ -223,8 +223,6 @@ class WebotsController:
             value = self.sensors[i].getValue()
             js.position.append(value)
             js.effort.append(self.motors[i].getTorqueFeedback())
-        if self.ros_active:
-            self.pub_js.publish(js)
         return js
 
     def publish_joint_states(self):


### PR DESCRIPTION
## Proposed changes
In the webots controller, the joint positions are published twice, once in `publish_joint_states` and once in `get_joint_state_msg`. This PR removes the undesired side effect from `get_joint_state_msg`.

## Necessary checks
- [x] Run `catkin build`
- [ ] ~Write documentation~
- [ ] ~Create issues for future work~
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

