### PR TITLE
Reduce SEA size to avoid collisions

### DIFF
--- a/wolfgang_description/urdf/robot.urdf
+++ b/wolfgang_description/urdf/robot.urdf
@@ -2957,7 +2957,7 @@
     <collision>
       <origin rpy="3.88389e-31 -1.5433e-31 1.35585e-31" xyz="-2.02057e-34 1.07341e-34 0.0045"/>
       <geometry>
-        <cylinder length="0.009" radius="0.025"/>
+        <cylinder length="0.009" radius="0.02"/>
       </geometry>
     </collision>
     <visual>
@@ -2972,7 +2972,7 @@
     <collision>
       <origin rpy="-8.16317e-16 -2.22045e-16 3.14159" xyz="-1.95677e-17 -5.41482e-17 0.0115"/>
       <geometry>
-        <cylinder length="0.005" radius="0.025"/>
+        <cylinder length="0.005" radius="0.02"/>
       </geometry>
     </collision>
     <visual>


### PR DESCRIPTION
## Proposed changes
This reduces the size of the neck SEA to avoid a collision between the head and the torso.

## Related issues
bit-bots/bitbots_behavior#85

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

