### PR TITLE
Remove other controller from robot supervisor world

### DIFF
--- a/wolfgang_webots_sim/worlds/robot_supervisor.wbt
+++ b/wolfgang_webots_sim/worlds/robot_supervisor.wbt
@@ -50,7 +50,3 @@ DEF ball RobocupSoccerBall {
 RobocupSoccerField {
   size "kid"
 }
-DEF supervisor_robot hl_supervisor {
-  name "supervisor_robot"
-  controller "<extern>"
-}


### PR DESCRIPTION
## Proposed changes
Remove the second controller from the robot supervisor world that was added in #123 on accident.

## Necessary checks
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

