### PR TITLE
Fix right pressure stamp

### DIFF
--- a/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_robot_controller.py
+++ b/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_robot_controller.py
@@ -343,7 +343,7 @@ class RobotController:
         left_pressure.right_back = self.pressure_sensors[3].getValues()[2]
 
         right_pressure = FootPressure()
-        left_pressure.header.stamp = current_time
+        right_pressure.header.stamp = current_time
         right_pressure.left_back = self.pressure_sensors[4].getValues()[2]
         right_pressure.left_front = self.pressure_sensors[5].getValues()[2]
         right_pressure.right_front = self.pressure_sensors[6].getValues()[2]


### PR DESCRIPTION
## Proposed changes
Fixes timestamp of right foot pressure sensor in `webots_robots_controller`.

## Necessary checks
~- [ ] Run `catkin build`~
~- [ ] Write documentation~
~- [ ] Create issues for future work~
- [ ] Test on your machine
~- [ ] Test on the robot~
- [x] Put the PR on our Project board

