### PR TITLE
Adapt proto file for RoboCup model submission

### DIFF
--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -591,7 +591,7 @@ PROTO Wolfgang [
                         DEF r_wrist Solid {
                           translation 0.000000 -0.226182 -0.023500
                           rotation 0.577350 -0.577352 -0.577350 2.094399
-                          name "r_wrist"
+                          name "r_wrist [hand]"
                         }
                       ]
                       name "r_lower_arm [arm]"
@@ -1134,7 +1134,7 @@ PROTO Wolfgang [
                         DEF l_wrist Solid {
                           translation -0.000000 -0.225182 -0.023500
                           rotation -0.577350 0.577352 -0.577350 2.094399
-                          name "l_wrist"
+                          name "l_wrist [hand]"
                         }
                       ]
                       name "l_lower_arm [arm]"

--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -8,7 +8,7 @@ PROTO Wolfgang [
   field  SFVec3f     translation     0 0 0
   field  SFRotation  rotation        0 1 0 0
   field  SFString    name            "red player 1"  # Is `Robot.name`.
-  field  SFString    controller      "void"      # Is `Robot.controller`.
+  field  SFString    controller      "player"      # Is `Robot.controller`.
   field  MFString    controllerArgs  []          # Is `Robot.controllerArgs`.
   field  SFString    customData      ""          # Is `Robot.customData`.
   field  SFBool      supervisor      FALSE       # Is `Robot.supervisor`.


### PR DESCRIPTION
## Proposed changes
This pull request adds the `[hand]` tags required for the model submission and changes the default controller to `player`. The `player` controller is the controller serving the robocup api. I don't know if this controller will be set automatically or if it is required to manually set it.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

