### PR TITLE
Add wolfgang_webots_sim to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,7 @@
+@Library('bitbots_jenkins_library') import de.bitbots.jenkins.*;
+
+defineProperties()
+
+def pipeline = new BitbotsPipeline(this, env, currentBuild, scm)
+pipeline.configurePipelineForPackage(new PackagePipelineSettings(new PackageDefinition("wolfgang_webots_sim")))
+pipeline.execute()

--- a/wolfgang_webots_sim/.rdmanifest
+++ b/wolfgang_webots_sim/.rdmanifest
@@ -1,0 +1,22 @@
+---
+# See http://doku.bit-bots.de/meta/manual/software/ci.html#make-package-resolvable-in-ci
+check-presence-script: '#!/bin/bash
+
+  test -d $BITBOTS_CATKIN_WORKSPACE/src/wolfgang_webots_sim'
+depends:
+- bitbots_docs
+- bitbots_msgs
+- gazebo_msgs
+- imu_complementary_filter
+- nav_msgs
+- rosgraph_msgs
+- rospy
+- sensor_msgs
+- std_msgs
+- urdf
+- xvfb
+exec-path: wolfgang_robot-master/wolfgang_webots_sim
+install-script: '#!/bin/bash
+
+  cp -r . $BITBOTS_CATKIN_WORKSPACE/src/wolfgang_webots_sim'
+uri: https://github.com/bit-bots/wolfgang_robot/archive/refs/heads/master.tar.gz


### PR DESCRIPTION
## Proposed changes
Add jenkins configuration for the `wolfgang_webots_sim` package as well as an `.rdmanifest` file which makes it installable as a dependency.

merge https://github.com/bit-bots/bitbots_tools/pull/107 after this

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

