### PR TITLE
Add team.json

### DIFF
--- a/wolfgang_robocup_api/config/team.json
+++ b/wolfgang_robocup_api/config/team.json
@@ -1,0 +1,89 @@
+{
+  "name": "Bit-Bots",
+  "players": {
+    "1": {
+      "proto": "Wolfgang",
+      "dockerTag": "latest",
+      "dockerCmd": "start goalie 0",
+      "halfTimeStartingPose": {
+        "translation": [-3.6, -3.20, 0.43],
+        "rotation": [0.13, -0.13, -0.98, -1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.6, -3.20, 0.43],
+        "rotation": [0.0, -0.0, -1.0, -1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2.6, 0, 0.43],
+        "rotation": [0, 0.98, 0.13, 0.26]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.43],
+        "rotation": [-0.13, 0, 0.98, 3.14]
+      }
+    },
+    "2": {
+      "proto": "Wolfgang",
+      "dockerTag": "latest",
+      "dockerCmd": "start defense 1",
+      "halfTimeStartingPose": {
+        "translation": [-1.6, -3.20, 0.43],
+        "rotation": [0.13, -0.13, -0.98, -1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-1.6, -3.20, 0.43],
+        "rotation": [0.0, -0.0, -1.0, -1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2.6, 0, 0.43],
+        "rotation": [0, 0.98, 0.13, 0.26]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.43],
+        "rotation": [-0.13, 0, 0.98, 3.14]
+      }
+    },
+    "3": {
+      "proto": "Wolfgang",
+      "dockerTag": "latest",
+      "dockerCmd": "start defense 2",
+      "halfTimeStartingPose": {
+        "translation": [-3.6, 3.20, 0.43],
+        "rotation": [-0.13, -0.13, 0.98, -1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-3.6, 3.20, 0.43],
+        "rotation": [0.0, -0.0, 1.0, -1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2.6, 0, 0.43],
+        "rotation": [0, 0.98, 0.13, 0.26]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.43],
+        "rotation": [-0.13, 0, 0.98, 3.14]
+      }
+    },
+    "4": {
+      "proto": "Wolfgang",
+      "dockerTag": "latest",
+      "dockerCmd": "start offense 0",
+      "halfTimeStartingPose": {
+        "translation": [-1.6, 3.20, 0.43],
+        "rotation": [-0.13, -0.13, 0.98, -1.57]
+      },
+      "reentryStartingPose": {
+        "translation": [-1.6, 3.20, 0.43],
+        "rotation": [0.0, -0.0, 1.0, -1.57]
+      },
+      "shootoutStartingPose": {
+        "translation": [2.6, 0, 0.43],
+        "rotation": [0, 0.98, 0.13, 0.26]
+      },
+      "goalKeeperStartingPose": {
+        "translation": [-4.47, 0, 0.43],
+        "rotation": [-0.13, 0, 0.98, 3.14]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes
This adds a team.json file for the RoboCup with four robots in four different positions. They are set up as a goalie, two defense players, and one offense player. I did not test the reentryStartingPose yet, because my autoreferee does not seem to work correctly at the moment.

## Related issues
Closes issue #133 (I think. There are four robots and I think @Flova changed the orientation such that the robot no longer falls at the beginning. However, they are not closer to the line)
