### PR TITLE
fix api restart

### DIFF
--- a/wolfgang_robocup_api/launch/wolfgang_robocup_api_bridge.launch
+++ b/wolfgang_robocup_api/launch/wolfgang_robocup_api_bridge.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="wolfgang_robocup_api" type="wolfgang_robocup_api.py" name="wolfgang_robocup_api" respawn="true" respawn_delay="1" output="screen">
+    <node pkg="wolfgang_robocup_api" type="wolfgang_robocup_api.py" name="wolfgang_robocup_api" required="true" respawn_delay="1" output="screen">
         <rosparam command="load" file="$(find wolfgang_robocup_api)/config/config.yaml" />
     </node>
     <include file="$(find wolfgang_webots_sim)/launch/imu_filter_sim.launch" />

--- a/wolfgang_robocup_api/launch/wolfgang_robocup_api_bridge.launch
+++ b/wolfgang_robocup_api/launch/wolfgang_robocup_api_bridge.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="wolfgang_robocup_api" type="wolfgang_robocup_api.py" name="wolfgang_robocup_api" required="true" respawn_delay="1" output="screen">
+    <node pkg="wolfgang_robocup_api" type="wolfgang_robocup_api.py" name="wolfgang_robocup_api" required="true" output="screen">
         <rosparam command="load" file="$(find wolfgang_robocup_api)/config/config.yaml" />
     </node>
     <include file="$(find wolfgang_webots_sim)/launch/imu_filter_sim.launch" />

--- a/wolfgang_robocup_api/src/wolfgang_robocup_api/wolfgang_robocup_api.py
+++ b/wolfgang_robocup_api/src/wolfgang_robocup_api/wolfgang_robocup_api.py
@@ -141,7 +141,7 @@ class WolfgangRobocupApi():
             sock.connect((host, port))
             response = sock.recv(8).decode('utf8')
         except ConnectionRefusedError:
-            rospy.loginfo(rospy.logerr(f"Connection refused by '{addr}'", logger_name="rc_api"))
+            rospy.logerr(f"Connection refused by '{addr}'", logger_name="rc_api")
             return None
         if response == "Welcome\0":
             rospy.loginfo(f"Successfully connected to '{addr}'", logger_name="rc_api")

--- a/wolfgang_robocup_api/src/wolfgang_robocup_api/wolfgang_robocup_api.py
+++ b/wolfgang_robocup_api/src/wolfgang_robocup_api/wolfgang_robocup_api.py
@@ -5,6 +5,8 @@ import sys
 import math
 import re
 import socket
+import time
+
 import rospy
 import rospkg
 import struct
@@ -72,7 +74,11 @@ class WolfgangRobocupApi():
         self.create_subscribers()
 
         addr = os.environ.get('ROBOCUP_SIMULATOR_ADDR')
-        self.socket = self.get_connection(addr)
+        # we will try multiple times till we manage to get a connection
+        self.socket = None
+        while not rospy.is_shutdown() and self.socket is None:
+            self.socket = self.get_connection(addr)
+            time.sleep(1) #dont use ros time since it is maybe not available
 
         self.first_run = True
         self.published_camera_info = False
@@ -131,17 +137,21 @@ class WolfgangRobocupApi():
         port = int(port)
         rospy.loginfo(f"Connecting to '{addr}'", logger_name="rc_api")
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect((host, port))
-        response = sock.recv(8).decode('utf8')
+        try:
+            sock.connect((host, port))
+            response = sock.recv(8).decode('utf8')
+        except ConnectionRefusedError:
+            rospy.loginfo(rospy.logerr(f"Connection refused by '{addr}'", logger_name="rc_api"))
+            return None
         if response == "Welcome\0":
             rospy.loginfo(f"Successfully connected to '{addr}'", logger_name="rc_api")
             return sock
         elif response == "Refused\0":
             rospy.logerr(f"Connection refused by '{addr}'", logger_name="rc_api")
-            sys.exit(1)
+            return None
         else:
             rospy.logerr(f"Could not connect to '{addr}'\nGot response '{response}'", logger_name="rc_api")
-            sys.exit(1)
+            return None
 
     def close_connection(self):
         self.socket.close()


### PR DESCRIPTION
## Proposed changes
Lets api try to reconnect in a loop instead of dying and being respawned through roslaunch. Just to improve the terminal spam


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

