### PR TITLE
Add ROBOCUP_MIRROR_SERVER_IP to start.sh

### DIFF
--- a/wolfgang_robocup_api/scripts/start.sh
+++ b/wolfgang_robocup_api/scripts/start.sh
@@ -42,17 +42,29 @@ if [[ -z "$ROBOCUP_SIMULATOR_ADDR" ]]; then
     exit 2
 fi
 
+if [[ -z "$ROBOCUP_MIRROR_SERVER_IP" ]]; then
+    echo "ROBOCUP_MIRROR_SERVER_IP is not set! Exiting."
+    exit 2
+fi
+
 BRINGUP_DIR=$(rospack find bitbots_bringup)
 
-if [[ -z $BRINGUP_DIR ]]; then
+if [[ -z "$BRINGUP_DIR" ]]; then
     echo "Could not find bitbots_bringup! Did you source ROS?"
     exit 2
 fi
 
 GAME_CONTROLLER_DIR=$(rospack find humanoid_league_game_controller)
 
-if [[ -z $BRINGUP_DIR ]]; then
+if [[ -z "$GAME_CONTROLLER_DIR" ]]; then
     echo "Could not find humanoid_league_game_controller!"
+    exit 2
+fi
+
+TEAM_COMM_DIR=$(rospack find humanoid_league_team_communication)
+
+if [[ -z "$TEAM_COMM_DIR" ]]; then
+    echo "Could not find humanoid_league_team_communication!"
     exit 2
 fi
 
@@ -72,6 +84,8 @@ cat > $GAME_CONTROLLER_DIR/config/game_controller.yaml << EOF
 team_id: $TEAM_ID
 bot_id: $ROBOCUP_ROBOT_ID
 EOF
+
+sed -i "/^target_host:/s/^.*$/target_host: $ROBOCUP_MIRROR_SERVER_IP/" $TEAM_COMM_DIR/config/team_communication_config.yaml
 
 #############
 # Start ROS #


### PR DESCRIPTION
## Proposed changes
This adds the ROBOCUP_MIRROR_SERVER_IP as an environment variable to `start.sh`. When set to `127.0.0.1`, the team comm will be started in local mode, else it will connect to the udp bouncer on the given server. Must be merged after bit-bots/humanoid_league_misc#91.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

