### PR TITLE
Set shootoutStartingPose correctly

### DIFF
--- a/wolfgang_robocup_api/config/team.json
+++ b/wolfgang_robocup_api/config/team.json
@@ -14,7 +14,7 @@
         "rotation": [0.0, -0.0, -1.0, -1.57]
       },
       "shootoutStartingPose": {
-        "translation": [2.5, -0.0, 0.43],
+        "translation": [2.75, -0.0, 0.43],
         "rotation": [0.0, -0.0, -1.0, 0.0]
       },
       "goalKeeperStartingPose": {
@@ -35,11 +35,11 @@
         "rotation": [0.0, -0.0, -1.0, -1.57]
       },
       "shootoutStartingPose": {
-        "translation": [2.5, -0.0, 0.43],
+        "translation": [-1.6, -3.20, 0.43],
         "rotation": [0.0, -0.0, -1.0, 0.0]
       },
       "goalKeeperStartingPose": {
-        "translation": [-4.475, -0.0, 0.43],
+        "translation": [-1.6, -3.20, 0.43],
         "rotation": [0.0, -0.0, -1.0, 0.0]
       }
     },
@@ -56,11 +56,11 @@
         "rotation": [0.0, -0.0, 1.0, -1.57]
       },
       "shootoutStartingPose": {
-        "translation": [2.5, -0.0, 0.43],
+        "translation": [-3.6, 3.20, 0.43],
         "rotation": [0.0, -0.0, -1.0, 0.0]
       },
       "goalKeeperStartingPose": {
-        "translation": [-4.475, -0.0, 0.43],
+        "translation": [-3.6, 3.20, 0.43],
         "rotation": [0.0, -0.0, -1.0, 0.0]
       }
     },
@@ -77,11 +77,11 @@
         "rotation": [0.0, -0.0, 1.0, -1.57]
       },
       "shootoutStartingPose": {
-        "translation": [2.5, -0.0, 0.43],
+        "translation": [-1.6, 3.20, 0.43],
         "rotation": [0.0, -0.0, -1.0, 0.0]
       },
       "goalKeeperStartingPose": {
-        "translation": [-4.475, -0.0, 0.43],
+        "translation": [-1.6, 3.20, 0.43],
         "rotation": [0.0, -0.0, -1.0, 0.0]
       }
     }


### PR DESCRIPTION
## Proposed changes
With this PR, the shootoutStartingPose of the first robot is adapted to be closer to the ball. The other robots are set to their normal starting poses for the shootout and for the goalie's position.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

