### PR TITLE
Set respawn="true" for the robocup api in docker

### DIFF
--- a/wolfgang_robocup_api/docker/Dockerfile
+++ b/wolfgang_robocup_api/docker/Dockerfile
@@ -80,8 +80,6 @@ RUN cd src/bitbots_meta && make vision-files
 RUN cp src/bitbots_meta/wolfgang_robot/wolfgang_robocup_api/scripts/start.sh .local/bin/start
 # Set respawn="true" for all nodes
 RUN bash -c "find -name '*.launch' | xargs sed -i '/<node/s/ respawn=\"\w\+\"//;/<node/s/ required=\"\w\+\"//;/<node/s/<node/<node respawn=\"true\"/'"
-# In the robocup api, set required="true"
-RUN sed -i "/<node/s/respawn/required/" src/bitbots_meta/wolfgang_robot/wolfgang_robocup_api/launch/wolfgang_robocup_api_bridge.launch
 
 # Volume for logs
 VOLUME /robocup-logs


### PR DESCRIPTION
## Proposed changes
The RoboCup API was previously set to `required="true"`, but since the software is not automatically restarted, this does not have the desired effect. This PR changes it to `respawn="true"`, like all other nodes.

## Related issues
Closes #174.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

