### PR TITLE
Fix location of required/respawn for docker

### DIFF
--- a/wolfgang_webots_sim/launch/simulation.launch
+++ b/wolfgang_webots_sim/launch/simulation.launch
@@ -25,10 +25,10 @@
     <rosparam command="delete" param="/webots_pid$(arg sim_id)"/>
 
     <!-- start simulation and supervisor either with or without gui -->
-    <node pkg="wolfgang_webots_sim" type="start_simulator.sh" name="webots_sim"
-          output="screen" required="true" args="$(arg multi_robot_flag) $(arg gui_flag) $(arg headless_flag)"/>
-    <node pkg="wolfgang_webots_sim" type="start_webots_ros_supervisor.sh" name="webots_ros_supervisor"
-          output="screen" respawn="true"/>
+    <node pkg="wolfgang_webots_sim" type="start_simulator.sh" name="webots_sim" required="true" 
+          output="screen" args="$(arg multi_robot_flag) $(arg gui_flag) $(arg headless_flag)"/>
+    <node pkg="wolfgang_webots_sim" type="start_webots_ros_supervisor.sh" name="webots_ros_supervisor" respawn="true"
+          output="screen" />
 
     <group unless="$(arg multi_robot)">
         <include file="$(find wolfgang_webots_sim)/launch/single_robot_controller.launch">


### PR DESCRIPTION
## Proposed changes
The Dockerfile currently does very dirty stuff to set respawn to true for all nodes. The replacing script is only looking in the same line as the opening `<node` tag, which does not work when the tag is set in the next line.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board