### PR TITLE
Add torque control to webots sim

### DIFF
--- a/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_robot_controller.py
+++ b/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_robot_controller.py
@@ -209,19 +209,28 @@ class RobotController:
         self.camera_counter = (self.camera_counter + 1) % CAMERA_DIVIDER
 
     def command_cb(self, command: JointCommand):
-        for i, name in enumerate(command.joint_names):
-            try:
-                motor_index = self.external_motor_names.index(name)
-                self.motors[motor_index].setPosition(command.positions[i])
-                if len(command.velocities) == 0 or command.velocities[i] == -1:
-                    self.motors[motor_index].setVelocity(self.motors[motor_index].getMaxVelocity())
-                else:
-                    self.motors[motor_index].setVelocity(command.velocities[i])
-                if not len(command.accelerations) == 0:
-                    self.motors[motor_index].setAcceleration(command.accelerations[i])
+        if len(command.positions) != 0:
+            # position control
+            for i, name in enumerate(command.joint_names):
+                try:
+                    motor_index = self.external_motor_names.index(name)
+                    self.motors[motor_index].setPosition(command.positions[i])
+                    if len(command.velocities) == 0 or command.velocities[i] == -1:
+                        self.motors[motor_index].setVelocity(self.motors[motor_index].getMaxVelocity())
+                    else:
+                        self.motors[motor_index].setVelocity(command.velocities[i])
 
-            except ValueError:
-                print(f"invalid motor specified ({name})")
+                except ValueError:
+                    print(f"invalid motor specified ({name})")
+        else:
+            # torque control
+            for i, name in enumerate(command.joint_names):
+                try:
+                    motor_index = self.external_motor_names.index(name)
+                    self.motors[motor_index].setTorque(command.accelerations[i])
+                except ValueError:
+                    print(f"invalid motor specified ({name})")
+
 
     def set_head_tilt(self, pos):
         self.motors[-1].setPosition(pos)


### PR DESCRIPTION
## Proposed changes
Adds torque control to the webots sim controller.
The change is required for bit-bots/bitbots_motion#298.
This change is not used in the production docker, so it should not break the system.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

