### PR TITLE
Remove nth_image from record bag

### DIFF
--- a/wolfgang_robocup_api/launch/record_bag.launch
+++ b/wolfgang_robocup_api/launch/record_bag.launch
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-    <arg name="nth_image" default="15" doc="records every nth image" />
     <arg name="out_dir" default="/robocup-logs" doc="Output directory" />
 
     <node name="record_rosbag_drop_images" pkg="topic_tools" type="drop"

--- a/wolfgang_robocup_api/launch/robocup_teamplayer.launch
+++ b/wolfgang_robocup_api/launch/robocup_teamplayer.launch
@@ -1,13 +1,11 @@
 <?xml version="1.0"?>
 <launch>
     <arg name="record" default="true" doc="true: records rosbag" />
-    <arg name="nth_image" default="15" doc="records every nth image" />
     <arg name="out_dir" default="/robocup-logs" doc="Output directory" />
 
     <!-- record rosbag -->
     <group if="$(arg record)">
         <include file="$(find wolfgang_robocup_api)/launch/record_bag.launch">
-            <arg name="nth_image" default="$(arg nth_image)" />
             <arg name="out_dir" default="$(arg out_dir)" />
         </include>
     </group>


### PR DESCRIPTION
## Proposed changes
Remove nth_image from record bag as it is not used

## Related issues

## Necessary checks
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

