### PR TITLE
added condition in case of supervisor robot to fix issue with nontype…

### DIFF
--- a/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_supervisor_controller.py
+++ b/wolfgang_webots_sim/src/wolfgang_webots_sim/webots_supervisor_controller.py
@@ -61,6 +61,8 @@ class SupervisorController:
             if name_field is not None and node.getType() == Node.ROBOT:
                 # this is a robot
                 name = name_field.getSFString()
+                if name == "supervisor_robot":
+                    continue
                 self.robot_nodes[name] = node
                 self.translation_fields[name] = node.getField("translation")
                 self.rotation_fields[name] = node.getField("rotation")


### PR DESCRIPTION
… errors

## Proposed changes
added extra condition in case the robot is the supervisor robot

## Related issues
Without this recording a rosbag in webots results in nontype errors because the supervisor robot has no joints

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [X] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

