### PR TITLE
Fix setenvs.sh for local webots installation and python 3.8

### DIFF
--- a/wolfgang_webots_sim/scripts/setenvs.sh
+++ b/wolfgang_webots_sim/scripts/setenvs.sh
@@ -1,6 +1,8 @@
 #!/bin/zsh
 
-export WEBOTS_HOME=/usr/local/webots
+export WEBOTS_HOME=${WEBOTS_HAME:-/usr/local/webots}
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${WEBOTS_HOME}/lib/controller
 [[ -f /usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4 ]] && export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
-export PYTHONPATH=$PYTHONPATH:${WEBOTS_HOME}/lib/controller/python36:$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )
+[[ -d ${WEBOTS_HOME}/lib/controller/python36 ]] && export PYTHONPATH=$PYTHONPATH:${WEBOTS_HOME}/lib/controller/python36
+[[ -d ${WEBOTS_HOME}/lib/controller/python38 ]] && export PYTHONPATH=$PYTHONPATH:${WEBOTS_HOME}/lib/controller/python38
+export PYTHONPATH=$PYTHONPATH:$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )


### PR DESCRIPTION
## Proposed changes
This pull request makes `setenvs.sh` respect an existing `WEBOTS_HOME` variable and support Python 3.8.

## Necessary checks
- [x] Test on your machine
- [x] Put the PR on our Project board

