### PR TITLE
fix imu orientation

### DIFF
--- a/wolfgang_pybullet_sim/src/wolfgang_pybullet_sim/ros_interface.py
+++ b/wolfgang_pybullet_sim/src/wolfgang_pybullet_sim/ros_interface.py
@@ -113,7 +113,7 @@ class ROSInterface:
         self.joint_publisher.publish(self.get_joint_state_msg())
 
     def get_imu_msg(self):
-        position, orientation = self.simulation.get_robot_pose()
+        orientation = self.simulation.get_imu_quaternion()
         self.imu_msg.orientation.x = orientation[0]
         self.imu_msg.orientation.y = orientation[1]
         self.imu_msg.orientation.z = orientation[2]


### PR DESCRIPTION
## Proposed changes
Fixes imu orientation so that it is in relation to gravity vector and not global coordinate frame

## Related issues
closes https://github.com/bit-bots/wolfgang_robot/issues/122

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

