### PR TITLE
Remove new webots test from Docker

### DIFF
--- a/wolfgang_robocup_api/docker/Dockerfile
+++ b/wolfgang_robocup_api/docker/Dockerfile
@@ -79,7 +79,8 @@ RUN rosdep install -iry --from-paths src && \
 # Delete some tests (has to happen before catkin build)
 RUN cd src/bitbots_meta && \
     rm bitbots_tools/bitbots_test/test/rostests/test_webots_simulator.launch \
-       bitbots_navigation/bitbots_localization/test/rostests/test_inital_localization_side.launch
+       bitbots_navigation/bitbots_localization/test/rostests/test_inital_localization_side.launch \
+       bitbots_motion/bitbots_quintic_walk/test/rostests/test_walk.launch
 
 RUN catkin build
 


### PR DESCRIPTION
## Proposed changes
In the docker, we never test the webots test because there is no webots installed. Currently, the only way to do that is to remove these tests manually. This removes a new webots test in the walking that was recently added.
