### PR TITLE
webots: add option for simplified foot shape

### DIFF
--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -17,6 +17,7 @@ PROTO Wolfgang [
   field  SFBool      enableBoundingObject TRUE      # Is `Robot.enableBoundingObject`.
   field  SFBool      enablePhysics   TRUE           # Is `Robot.enablePhysics`.
   field  SFBool      enableFootSensors TRUE         # Is `Robot.enableFootSensors`.
+  field  SFBool      simplifyFootCollision FALSE    # Is `Robot.enableFootSensors`.
   field  SFFloat     transparency    0              # Is `Robot.transparency`
   field  SFFloat     cameraFOV       1.04
   field  SFInt32     cameraWidth     800
@@ -2282,6 +2283,7 @@ PROTO Wolfgang [
                                         ]
                                         name "r_foot [foot]"
                                         %{if fields.enableBoundingObject.value then}%
+                                        %{if not fields.simplifyFootCollision.value then}%
                                         boundingObject Group {
                                           children [
                                             Transform {
@@ -2322,6 +2324,7 @@ PROTO Wolfgang [
                                             }
                                           ]
                                         }
+                                        %{ end }%
                                         %{ end }%
                                         %{if fields.enablePhysics.value then}%
                                           physics Physics {
@@ -3757,6 +3760,7 @@ PROTO Wolfgang [
                                         ]
                                         name "l_foot [foot]"
                                         %{if fields.enableBoundingObject.value then}%
+                                        %{if not fields.simplifyFootCollision.value then}%
                                         boundingObject Group {
                                           children [
                                             Transform {
@@ -3800,6 +3804,7 @@ PROTO Wolfgang [
 
                                           ]
                                         }
+                                        %{ end }%
                                         %{ end }%
                                         %{if fields.enablePhysics.value then}%
                                           physics Physics {

--- a/wolfgang_webots_sim/protos/WolfgangOptimization.proto
+++ b/wolfgang_webots_sim/protos/WolfgangOptimization.proto
@@ -15,6 +15,7 @@ PROTO WolfgangOptimization [
   field  SFBool      enableBoundingObject TRUE      # Is `Robot.enableBoundingObject`.
   field  SFBool      enablePhysics   TRUE           # Is `Robot.enablePhysics`.
   field  SFBool      enableFootSensors TRUE         # Is `Robot.enableFootSensors`.
+  field  SFBool      simplifyFootCollision FALSE    # Is `Robot.enableFootSensors`.
   field  SFFloat     transparency    0              # Is `Robot.transparency`
   field  MFNode      externalCamera NULL
 ]
@@ -32,6 +33,7 @@ PROTO WolfgangOptimization [
     enablePhysics IS enablePhysics
     transparency IS transparency
     enableFootSensors IS enableFootSensors
+    simplifyFootCollision IS simplifyFootCollision
     externalCamera IS externalCamera
   }
 }

--- a/wolfgang_webots_sim/worlds/deep_quintic_wolfgang.wbt
+++ b/wolfgang_webots_sim/worlds/deep_quintic_wolfgang.wbt
@@ -45,6 +45,7 @@ DEF lernbot WolfgangOptimization {
   name "lernbot"
   controller "<extern>"
   supervisor TRUE
+  simplifyFootCollision TRUE
   externalCamera [     
     Camera {
       translation 0 -1.5 0  


### PR DESCRIPTION
## Proposed changes
This way foot is really just the strain gauges. this way the footsensors are working better

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

