### PR TITLE
Port sim to webots 2022b

### DIFF
--- a/wolfgang_webots_sim/launch/simulation.launch
+++ b/wolfgang_webots_sim/launch/simulation.launch
@@ -6,7 +6,7 @@
     <arg name="num_robots" default="4"
          description="Number of robots for which a ROS controller is started. 1 if multi_robot=True "/>
     <arg name="multi_robot" default="false" description="Start world with either one or four robots"/>
-    <arg name="sim_id" default="" description="Namespace if multiple simulations should be run at the same time"/>
+    <arg name="sim_port" default="1234" description="Port used for the simulator communication. Relevant if multiple simulations are run at the same time"/>
     <arg name="camera" default="true" description="Turn on or off the camera (to speed up if only motion is required)"/>
     <arg name="recognition" default="false" description="Turn on or off automatic recognition for collection of training data"/>
     <arg name="robot_type" default="wolfgang" description="What type of robot should be used"/>
@@ -17,12 +17,13 @@
 
     <!-- start simulation and supervisor either with or without gui -->
     <node pkg="wolfgang_webots_sim" exec="start_simulator.py" name="webots_sim"
-          output="screen" args="$(var multi_robot_flag) $(var gui_flag) $(var headless_flag) --robot-type $(var robot_type)"/>
-    <node pkg="wolfgang_webots_sim" exec="start_webots_ros_supervisor.py" name="webots_ros_supervisor" output="screen" />
+          output="screen" args="$(var multi_robot_flag) $(var gui_flag) $(var headless_flag) --sim-port $(var sim_port) --robot-type $(var robot_type)"/>
+    <node pkg="wolfgang_webots_sim" exec="start_webots_ros_supervisor.py" name="webots_ros_supervisor" output="screen" args="--sim-port $(var sim_port)"/>
 
     <group unless="$(var multi_robot)">
         <include file="$(find-pkg-share wolfgang_webots_sim)/launch/single_robot_controller.launch">
             <arg name="camera" value="$(var camera)"/>
+            <arg name="sim_port" value="$(var sim_port)"/>
             <arg name="recognition" value="$(var recognition)"/>
             <arg name="robot_type" value="$(var robot_type)"/>
         </include>
@@ -37,6 +38,7 @@
             <include file="$(find-pkg-share wolfgang_webots_sim)/launch/single_robot_controller.launch">
                 <arg name="robot_name" value="amy"/>
                 <arg name="tf_prefix" value="amy/"/>
+                <arg name="sim_port" value="$(var sim_port)"/>
                 <arg name="void_controller" value="$(eval '\'$(var num_robots)\' &lt; 1')"/>
                 <arg name="camera" value="$(var camera)"/>
                 <arg name="recognition" value="$(var recognition)"/>
@@ -48,6 +50,7 @@
             <include file="$(find-pkg-share wolfgang_webots_sim)/launch/single_robot_controller.launch">
                 <arg name="robot_name" value="rory"/>
                 <arg name="tf_prefix" value="rory/"/>
+                <arg name="sim_port" value="$(var sim_port)"/>
                 <arg name="void_controller" value="$(eval '\'$(var num_robots)\' &lt; 2')"/>
                 <arg name="camera" value="$(var camera)"/>
                 <arg name="recognition" value="$(var recognition)"/>
@@ -59,6 +62,7 @@
             <include file="$(find-pkg-share wolfgang_webots_sim)/launch/single_robot_controller.launch">
                 <arg name="robot_name" value="jack"/>
                 <arg name="tf_prefix" value="jack/"/>
+                <arg name="sim_port" value="$(var sim_port)"/>
                 <arg name="void_controller" value="$(eval '\'$(var num_robots)\' &lt; 3')"/>
                 <arg name="camera" value="$(var camera)"/>
                 <arg name="recognition" value="$(var recognition)"/>
@@ -70,6 +74,7 @@
             <include file="$(find-pkg-share wolfgang_webots_sim)/launch/single_robot_controller.launch">
                 <arg name="robot_name" value="donna"/>
                 <arg name="tf_prefix" value="donna/"/>
+                <arg name="sim_port" value="$(var sim_port)"/>
                 <arg name="void_controller" value="$(eval '\'$(var num_robots)\' &lt; 4')"/>
                 <arg name="camera" value="$(var camera)"/>
                 <arg name="recognition" value="$(var recognition)"/>

--- a/wolfgang_webots_sim/launch/single_robot_controller.launch
+++ b/wolfgang_webots_sim/launch/single_robot_controller.launch
@@ -6,6 +6,7 @@
   <arg name="recognition" default="false" description="Turn on or off automatic recognition for collection of training data"/>
   <arg name="void_controller" default="false" description="If set to true, the robot is not controllable"/>
   <arg name="robot_type" default="wolfgang" description="What type of robot should be used"/>
+  <arg name="sim_port" default="1234" description="Port used for the simulator communication. Relevant if multiple simulations are run at the same time"/>
 
   <arg name="void_flag" default="$(eval '\'--void-controller\' if \'$(var void_controller)\'==\'true\' else \'\'')"
        description="do not set, used internally"/>
@@ -15,7 +16,7 @@
        description="do not set, used internally"/>
 
   <node pkg="wolfgang_webots_sim" exec="start_single.py" name="webots_ros_interface" respawn="true" output="screen"
-        args="--robot_name $(var robot_name) $(var void_flag) $(var recognition_flag) $(var camera_disable_flag) --robot-type $(var robot_type)">
+        args="--robot_name $(var robot_name) $(var void_flag) $(var recognition_flag) $(var camera_disable_flag) --robot-type $(var robot_type) --sim-port $(var sim_port)">
     <param name="base_link_frame" value="$(var tf_prefix)base_link"/>
     <param name="r_sole_frame" value="$(var tf_prefix)r_sole"/>
     <param name="l_sole_frame" value="$(var tf_prefix)l_sole"/>

--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -1,4 +1,4 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the Wolfgang
@@ -701,7 +701,7 @@ PROTO Wolfgang [
                         children [
                           Transform {
                             translation 0.000000 -0.163682 -0.005500
-                            rotation 0.000001 -0.707107 -0.707107 3.141591
+                            rotation -0.707107 -0.707107 0.000001 3.141591
                             children [
                               Cylinder {
                                 radius 0.04
@@ -720,7 +720,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 -0.193682 -0.005500
-                            rotation 0.000001 -0.707107 -0.707107 3.141591
+                            rotation -0.707107 -0.707107 0.000001 3.141591
                             children [
                               Cylinder {
                                 radius 0.032
@@ -757,7 +757,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 -0.163682 -0.023500
-                            rotation -1.000000 0.000000 0.000000 1.570794
+                            rotation 0.000000 0.000000 -1.000000 1.570794
                             children [
                               Cylinder {
                                 radius 0.04
@@ -767,7 +767,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 -0.193682 -0.023500
-                            rotation -1.000000 0.000000 0.000000 1.570794
+                            rotation 0.000000 0.000000 -1.000000 1.570794
                             children [
                               Cylinder {
                                 radius 0.032
@@ -795,7 +795,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 -0.163682 -0.041500
-                            rotation 0.000001 -0.707107 -0.707107 3.141591
+                            rotation -0.707107 -0.707107 0.000001 3.141591
                             children [
                               Cylinder {
                                 radius 0.04
@@ -814,7 +814,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 -0.193682 -0.041500
-                            rotation 0.000001 -0.707107 -0.707107 3.141591
+                            rotation -0.707107 -0.707107 0.000001 3.141591
                             children [
                               Cylinder {
                                 radius 0.032
@@ -872,7 +872,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation 0.025125 -0.144000 -0.023500
-                      rotation 0.577349 -0.577351 0.577351 2.094397
+                      rotation -0.577351 0.577349 -0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -882,7 +882,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation 0.025125 -0.014000 -0.023500
-                      rotation 0.577349 -0.577351 0.577351 2.094397
+                      rotation -0.577351 0.577349 -0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -910,7 +910,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation -0.025125 -0.144000 -0.023500
-                      rotation 0.577349 0.577351 -0.577351 2.094397
+                      rotation 0.577351 0.577349 0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -920,7 +920,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation -0.025125 -0.014000 -0.023500
-                      rotation 0.577349 0.577351 -0.577351 2.094397
+                      rotation 0.577351 0.577349 0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -978,7 +978,7 @@ PROTO Wolfgang [
             children [
               Transform {
                 translation -0.028450 0.042000 0.000000
-                rotation -0.000002 -0.000002 1.000000 1.570800
+                rotation -0.000002 1.000000 -0.000002 1.570800
                 children [
                   Cylinder {
                     radius 0.025
@@ -988,7 +988,7 @@ PROTO Wolfgang [
               }
               Transform {
                 translation -0.021450 0.042000 0.000000
-                rotation -0.000002 -0.000002 1.000000 1.570800
+                rotation -0.000002 1.000000 -0.000002 1.570800
                 children [
                   Cylinder {
                     radius 0.025
@@ -1279,7 +1279,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.163682 -0.041500
-                            rotation -1.000000 -0.000000 0.000000 1.570794
+                            rotation -0.000000 0.000000 -1.000000 1.570794
                             children [
                               Cylinder {
                                 radius 0.04
@@ -1298,7 +1298,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.193682 -0.041500
-                            rotation -1.000000 -0.000000 0.000000 1.570794
+                            rotation -0.000000 0.000000 -1.000000 1.570794
                             children [
                               Cylinder {
                                 radius 0.032
@@ -1326,7 +1326,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.163682 -0.023500
-                            rotation 0.000001 -0.707107 -0.707107 3.141591
+                            rotation -0.707107 -0.707107 0.000001 3.141591
                             children [
                               Cylinder {
                                 radius 0.04
@@ -1336,7 +1336,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.193682 -0.023500
-                            rotation 0.000001 -0.707107 -0.707107 3.141591
+                            rotation -0.707107 -0.707107 0.000001 3.141591
                             children [
                               Cylinder {
                                 radius 0.032
@@ -1364,7 +1364,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.163682 -0.005500
-                            rotation -1.000000 -0.000000 0.000000 1.570794
+                            rotation -0.000000 0.000000 -1.000000 1.570794
                             children [
                               Cylinder {
                                 radius 0.04
@@ -1383,7 +1383,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.193682 -0.005500
-                            rotation -1.000000 -0.000000 0.000000 1.570794
+                            rotation -0.000000 0.000000 -1.000000 1.570794
                             children [
                               Cylinder {
                                 radius 0.032
@@ -1468,7 +1468,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation -0.025125 -0.144000 -0.023500
-                      rotation 0.577349 0.577351 -0.577351 2.094397
+                      rotation 0.577351 0.577349 0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -1478,7 +1478,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation -0.025125 -0.014000 -0.023500
-                      rotation 0.577349 0.577351 -0.577351 2.094397
+                      rotation 0.577351 0.577349 0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -1497,7 +1497,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation 0.025125 -0.144000 -0.023500
-                      rotation 0.577349 -0.577351 0.577351 2.094397
+                      rotation -0.577351 0.577349 -0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -1507,7 +1507,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation 0.025125 -0.014000 -0.023500
-                      rotation 0.577349 -0.577351 0.577351 2.094397
+                      rotation -0.577351 0.577349 -0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.02
@@ -1547,7 +1547,7 @@ PROTO Wolfgang [
             children [
               Transform {
                 translation -0.028450 0.042000 -0.000000
-                rotation 0.707105 -0.707108 0.000001 3.141595
+                rotation -0.707108 0.000001 0.707105 3.141595
                 children [
                   Cylinder {
                     radius 0.025
@@ -1584,7 +1584,7 @@ PROTO Wolfgang [
               }
               Transform {
                 translation -0.021450 0.042000 -0.000000
-                rotation 0.707105 -0.707108 0.000001 3.141595
+                rotation -0.707108 0.000001 0.707105 3.141595
                 children [
                   Cylinder {
                     radius 0.025
@@ -2135,7 +2135,7 @@ PROTO Wolfgang [
                                             %{if fields.enableBoundingObject.value then}%
                                             boundingObject DEF CLEAT_CAPSULE Transform {
                                               translation 0.000000 0.000000 0.005000
-                                              rotation 1.000000 -0.000000 0.000000 1.570796
+                                              rotation -0.000000 0.000000 1.000000 1.570796
                                               children [
                                                 Capsule {
                                                   radius 0.006
@@ -2418,7 +2418,7 @@ PROTO Wolfgang [
                               children [
                                 Transform {
                                   translation 0.000000 0.049000 -0.000000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation 0 0.707107 -0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -2428,7 +2428,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 0.051500 -0.170000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -2438,7 +2438,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation -0.000000 0.051500 0.000000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -2448,7 +2448,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation -0.004000 0.051500 -0.165000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -2458,7 +2458,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.004000 0.051500 -0.005000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -2477,7 +2477,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.002500 -0.170000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -2487,7 +2487,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.002500 0.000000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -2497,7 +2497,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation -0.004000 -0.002500 -0.165000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -2507,7 +2507,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.004000 -0.002500 -0.005000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -2535,7 +2535,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.024000 0.000000
-                                  rotation 1.000000 0.000000 0.000000 3.141596
+                                  rotation 0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.0165
@@ -2545,7 +2545,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.014350 0.000000
-                                  rotation 1.000000 0.000000 0.000000 3.141596
+                                  rotation 0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.0105
@@ -2564,7 +2564,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.001500 -0.000000
-                                  rotation 1.000000 0.000000 0.000000 3.141596
+                                  rotation 0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -2574,7 +2574,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.003500 0.001350
-                                  rotation 1.000000 0.000000 0.000000 3.141596
+                                  rotation 0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.015
@@ -2623,7 +2623,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 0.001000 -0.000000
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.018
@@ -2633,7 +2633,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.009329 0.001000 -0.143000
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.01
@@ -2643,7 +2643,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.014840 0.001000 -0.132659
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.02
@@ -2671,7 +2671,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.009329 0.001000 -0.143000
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.01
@@ -2681,7 +2681,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.004010 0.001000 -0.002422
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2691,7 +2691,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.007707 0.001000 -0.006828
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2701,7 +2701,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.010583 0.001000 -0.011810
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2711,7 +2711,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.012551 0.001000 -0.017215
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2721,7 +2721,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.013550 0.001000 -0.022880
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2731,7 +2731,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.013550 0.001000 -0.028633
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2741,7 +2741,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.012551 0.001000 -0.034298
-                            rotation 1.000000 -0.000000 -0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2751,7 +2751,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.052000 -0.000000
-                            rotation 0.258819 -0.000002 0.965926 3.141589
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.018
@@ -2770,7 +2770,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.014000 -0.066000 -0.138000
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.014
@@ -2780,7 +2780,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.001000 -0.000000
-                            rotation 0.258819 -0.000002 0.965926 3.141589
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.018
@@ -2790,7 +2790,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.000000 -0.054000 -0.000000
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.018
@@ -2800,7 +2800,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.009329 -0.054000 -0.143000
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.01
@@ -2810,7 +2810,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.014840 -0.054000 -0.132659
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.02
@@ -2838,7 +2838,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.009329 -0.054000 -0.143000
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.01
@@ -2848,7 +2848,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.004010 -0.054000 -0.002422
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2858,7 +2858,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.007707 -0.054000 -0.006828
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2868,7 +2868,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.010583 -0.054000 -0.011810
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2878,7 +2878,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.012551 -0.054000 -0.017215
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2888,7 +2888,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.013550 -0.054000 -0.022880
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2898,7 +2898,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.013550 -0.054000 -0.028633
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -2908,7 +2908,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.012551 -0.054000 -0.034298
-                            rotation 1.000000 -0.000000 0.000000 3.141596
+                            rotation -0.000000 0.707107 0.707107 3.141596
                             children [
                               Cylinder {
                                 radius 0.017
@@ -3068,7 +3068,7 @@ PROTO Wolfgang [
               }
               Transform {
                 translation 0.0 -0.0006 0.0019999999999999983
-                rotation -5.551115123125783e-17 1.0 5.551115123125783e-17 1.5707963267948966
+                rotation 1.0 0.000000 0.000000 1.5707963267948966
                 children [
                   Cylinder {
                     height 0.004
@@ -3896,7 +3896,7 @@ PROTO Wolfgang [
                               children [
                                 Transform {
                                   translation 0.000000 0.024000 -0.000000
-                                  rotation 0.000000 1.000000 0.000000 0.000004
+                                  rotation 0.000000 0.707107 0.707107 3.141590
                                   children [
                                     Cylinder {
                                       radius 0.0165
@@ -3906,7 +3906,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 0.014350 -0.000000
-                                  rotation 0.000000 1.000000 0.000000 0.000004
+                                  rotation 0.000000 0.707107 0.707107 3.141590
                                   children [
                                     Cylinder {
                                       radius 0.0105
@@ -3925,7 +3925,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 0.003500 -0.001350
-                                  rotation 0.000000 1.000000 0.000000 0.000004
+                                  rotation 0.000000 0.707107 0.707107 3.141590
                                   children [
                                     Cylinder {
                                       radius 0.015
@@ -3935,7 +3935,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.050500 -0.000000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -3954,7 +3954,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.000000 -0.000000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -3964,7 +3964,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 -0.051500 -0.170000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -3974,7 +3974,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation -0.000000 -0.051500 0.000000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -3984,7 +3984,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation -0.004000 -0.051500 -0.165000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -3994,7 +3994,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.004000 -0.051500 -0.005000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -4013,7 +4013,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.000000 0.002500 -0.170000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -4023,7 +4023,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation -0.000000 0.002500 0.000000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.018
@@ -4033,7 +4033,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation -0.004000 0.002500 -0.165000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -4043,7 +4043,7 @@ PROTO Wolfgang [
                                 }
                                 Transform {
                                   translation 0.004000 0.002500 -0.005000
-                                  rotation 1.000000 -0.000000 -0.000000 3.141596
+                                  rotation -0.000000 0.707107 0.707107 3.141596
                                   children [
                                     Cylinder {
                                       radius 0.02
@@ -4101,7 +4101,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 -0.000000 0.050000
-                            rotation -1.000000 0.000000 -0.000000 1.570794
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.018
@@ -4138,7 +4138,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.014000 -0.138000 0.064000
-                            rotation 0.186158 0.694746 0.694746 2.773490
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.014
@@ -4148,7 +4148,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 0.000000 -0.001000
-                            rotation 1.000000 -0.000000 0.000000 1.570796
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.018
@@ -4158,7 +4158,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 -0.000000 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.018
@@ -4168,7 +4168,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.009329 -0.143000 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.01
@@ -4178,7 +4178,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.014840 -0.132659 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.02
@@ -4206,7 +4206,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.009329 -0.143000 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.01
@@ -4216,7 +4216,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.004010 -0.002422 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4226,7 +4226,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.007707 -0.006828 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4236,7 +4236,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.010583 -0.011810 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4246,7 +4246,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.012551 -0.017215 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4256,7 +4256,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.013550 -0.022880 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4266,7 +4266,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.013550 -0.028633 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4276,7 +4276,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.012551 -0.034298 -0.003000
-                            rotation -0.000001 0.707106 -0.707108 3.141591
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4286,7 +4286,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.000000 0.000000 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.018
@@ -4296,7 +4296,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.009329 -0.143000 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.01
@@ -4306,7 +4306,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.014840 -0.132659 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.02
@@ -4334,7 +4334,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation -0.009329 -0.143000 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.01
@@ -4344,7 +4344,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.004010 -0.002422 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4354,7 +4354,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.007707 -0.006828 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4364,7 +4364,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.010583 -0.011810 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4374,7 +4374,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.012551 -0.017215 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4384,7 +4384,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.013550 -0.022880 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4394,7 +4394,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.013550 -0.028633 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4404,7 +4404,7 @@ PROTO Wolfgang [
                           }
                           Transform {
                             translation 0.012551 -0.034298 0.052000
-                            rotation 0.000001 0.707108 -0.707106 3.141595
+                            rotation 0.707107 0.707107 0.000000 3.141590
                             children [
                               Cylinder {
                                 radius 0.017
@@ -4546,7 +4546,7 @@ PROTO Wolfgang [
               }
               Transform {
                 translation 0.0 -0.0006 0.0019999999999999983
-                rotation -5.551115123125783e-17 1.0 5.551115123125783e-17 1.5707963267948966
+                rotation 1.000000 0.000000 0.000000 1.5707963267948966
                 children [
                   Cylinder {
                     height 0.004
@@ -4712,10 +4712,10 @@ PROTO Wolfgang [
                   }
                   DEF camera_optical_frame Solid {
                     translation 0.043200 0.080000 -0.023500
-                    rotation 0.707105 -0.000001 0.707108 3.141591
+                    rotation -0.000001 0.707105 -0.707108 3.141591
                     children [
                       Camera {
-                        rotation 1.0 0.0 0.0 3.141591
+                        rotation 0.0 1.0 0.0 3.141591
                         name "camera"
                         fieldOfView IS cameraFOV
                         width IS cameraWidth
@@ -4799,7 +4799,7 @@ PROTO Wolfgang [
                   children [
                     Transform {
                       translation 0.035100 0.079500 -0.023500
-                      rotation 0.577349 -0.577351 0.577351 2.094397
+                      rotation -0.577351 0.577349 -0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.0215
@@ -4809,7 +4809,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation 0.021000 0.079500 -0.023500
-                      rotation 0.577349 -0.577351 0.577351 2.094397
+                      rotation -0.577351 0.577349 -0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.01675
@@ -4819,7 +4819,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation -0.000000 0.000000 0.004500
-                      rotation 1.000000 -0.000000 0.000000 1.570796
+                      rotation 0.000000 0.000000 1.000000 -1.570796
                       children [
                         Cylinder {
                           radius 0.025
@@ -4829,7 +4829,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation -0.000000 -0.000000 0.011500
-                      rotation 0.000001 0.707107 0.707107 3.141591
+                      rotation 0.707107 0.707107 0.000001 3.141591
                       children [
                         Cylinder {
                           radius 0.025
@@ -4866,7 +4866,7 @@ PROTO Wolfgang [
                     }
                     Transform {
                       translation 0.009000 0.079500 -0.023500
-                      rotation 0.577349 -0.577351 0.577351 2.094397
+                      rotation -0.577351 0.577349 -0.577351 2.094397
                       children [
                         Cylinder {
                           radius 0.014

--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -4,6 +4,71 @@
 # This is a proto file for Webots for the Wolfgang
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_ankleMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_baseplate_odroid_xu4_coreMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_basler_ace_gige_c-mount_v01Mesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_battery_cage_holderMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_battery_cageMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_battery_clipMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_batteryMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_camera_lower_basler_wolfgang_imu_v2_2Mesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_camera_side_basler_wolfgang_v2_2_leftMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_camera_side_basler_wolfgang_v2_2_rightMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_connector_shoulderMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_coreMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_dummy_speakerMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_flex_stollenMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_foot_coverMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_foot_printed_leftMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_foot_printed_rightMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_forcefoot_pcbMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_handMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_hip_u_connectorMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_imu_bottom_coverMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_imu_holderMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_knee_connectorMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_knee_spacerMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_lenseMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_load_cellMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_lower_armMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_lower_legMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_lower_leg_spacerMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_motor_connectorMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_mx-106_bodyMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_mx-64-bodyMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_nuc_bottomMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_nuc_frontMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_nuc_holder_left_backMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_nuc_holder_left_frontMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_nuc_holder_right_backMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_nuc_holder_right_frontMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_nuc_mainMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_part_1Mesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_power_regulatorMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_router_holder_leftMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_router_holder_rightMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_sea_connectorMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_sea_ninjaflexMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_shoulder_connectorMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_speaker_holderMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_springholder_bottomMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_spring_holder_lowerMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_springholder_newMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_spring_holder_upperMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_switch_holderMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_thrustbearingholderMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_torso_bottomMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_torso_bumper_leftMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_torso_bumper_rightMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_torso_topMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_upper_armMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_upper_arm_spacerMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_upper_legMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_upper_leg_spacerMesh.proto"
+EXTERNPROTO "Wolfgang_meshes/Wolfgang_xh-540Mesh.proto"
+EXTERNPROTO "Wolfgang_textures/WolfgangMarker.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/joints/protos/HingeJointWithBacklash.proto"
+
 PROTO Wolfgang [
   field  SFVec3f     translation     0 0 0
   field  SFRotation  rotation        0 1 0 0
@@ -17,7 +82,6 @@ PROTO Wolfgang [
   field  SFBool      enableBoundingObject TRUE      # Is `Robot.enableBoundingObject`.
   field  SFBool      enablePhysics   TRUE           # Is `Robot.enablePhysics`.
   field  SFBool      enableFootSensors TRUE         # Is `Robot.enableFootSensors`.
-  field  SFFloat     transparency    0              # Is `Robot.transparency`
   field  SFFloat     cameraFOV       1.04
   field  SFInt32     cameraWidth     800
   field  SFInt32     cameraHeight    600
@@ -76,7 +140,6 @@ PROTO Wolfgang [
         rotation -0.707105 0.000001 0.707108 3.141591
         children [
           Wolfgang_mx-64-bodyMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -85,7 +148,6 @@ PROTO Wolfgang [
         rotation -0.000000 -1.000000 -0.000000 1.570800
         children [
           Wolfgang_mx-64-bodyMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -94,7 +156,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_nuc_holder_right_frontMesh {
-           transparency IS transparency
           }
         ]
       }
@@ -103,7 +164,6 @@ PROTO Wolfgang [
         rotation 0.000000 1.000000 0.000000 0.000000
         children [
           Wolfgang_power_regulatorMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -112,7 +172,6 @@ PROTO Wolfgang [
         rotation -0.577350 -0.577352 0.577350 2.094399
         children [
           Wolfgang_torso_bumper_rightMesh {
-           transparency IS transparency
           }
         ]
       }
@@ -121,7 +180,6 @@ PROTO Wolfgang [
         rotation -0.000000 0.000000 -1.000000 1.570800
         children [
           Wolfgang_coreMesh {
-           transparency IS transparency
           }
         ]
       }
@@ -130,7 +188,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 -1.000000 1.570800
         children [
           Wolfgang_batteryMesh {
-           transparency IS transparency
           }
         ]
       }
@@ -139,7 +196,6 @@ PROTO Wolfgang [
         rotation 0.577350 -0.577352 -0.577350 2.094399
         children [
           Wolfgang_mx-106_bodyMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -148,7 +204,6 @@ PROTO Wolfgang [
         rotation -0.577350 0.577352 -0.577350 2.094399
         children [
           Wolfgang_torso_bumper_leftMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -157,7 +212,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_nuc_holder_right_backMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -166,7 +220,6 @@ PROTO Wolfgang [
         rotation 0.577350 -0.577352 -0.577350 2.094399
         children [
           Wolfgang_mx-106_bodyMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -175,7 +228,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_battery_clipMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -184,7 +236,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_nuc_holder_left_backMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -193,7 +244,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_nuc_bottomMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -202,7 +252,6 @@ PROTO Wolfgang [
         rotation -0.707105 0.000001 0.707108 3.141591
         children [
           Wolfgang_imu_holderMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -211,7 +260,6 @@ PROTO Wolfgang [
         rotation 0.000000 -0.000000 1.000000 1.570800
         children [
           Wolfgang_nuc_frontMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -220,7 +268,6 @@ PROTO Wolfgang [
         rotation 0.000000 1.000000 0.000000 0.000000
         children [
           Wolfgang_torso_bottomMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -238,7 +285,6 @@ PROTO Wolfgang [
                 %{else}%
                   baseColor  0.0, 0.0, 0.0
                  %{ end }%
-              transparency IS transparency
             }
             geometry Box {
               size 0.15 0.005 0.08
@@ -260,7 +306,6 @@ PROTO Wolfgang [
                 %{else}%
                   baseColor  0.0, 0.0, 0.0
                 %{ end }%
-                transparency IS transparency
               }
             geometry Box {
               size 0.15 0.005 0.08
@@ -273,7 +318,6 @@ PROTO Wolfgang [
         rotation -0.577350 -0.577352 0.577350 2.094399
         children [
           Wolfgang_router_holder_leftMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -282,7 +326,6 @@ PROTO Wolfgang [
         rotation 0.707105 -0.707108 -0.000001 3.141591
         children [
           Wolfgang_imu_bottom_coverMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -291,7 +334,6 @@ PROTO Wolfgang [
         rotation -0.577350 -0.577352 0.577350 2.094399
         children [
           Wolfgang_mx-64-bodyMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -300,7 +342,6 @@ PROTO Wolfgang [
         rotation -0.577350 -0.577352 0.577350 2.094399
         children [
           Wolfgang_torso_bumper_leftMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -309,7 +350,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_speaker_holderMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -318,7 +358,6 @@ PROTO Wolfgang [
         rotation -0.000000 0.000000 -1.000000 1.570800
         children [
           Wolfgang_baseplate_odroid_xu4_coreMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -327,7 +366,6 @@ PROTO Wolfgang [
         rotation -0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_nuc_mainMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -336,7 +374,6 @@ PROTO Wolfgang [
         rotation -0.577350 0.577352 -0.577350 2.094399
         children [
           Wolfgang_torso_bumper_rightMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -345,7 +382,6 @@ PROTO Wolfgang [
         rotation 0.577350 0.577352 0.577350 2.094399
         children [
           Wolfgang_switch_holderMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -354,7 +390,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_torso_topMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -363,7 +398,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_dummy_speakerMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -372,7 +406,6 @@ PROTO Wolfgang [
         rotation -0.577350 -0.577352 0.577350 2.094399
         children [
           Wolfgang_router_holder_rightMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -381,7 +414,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_battery_cage_holderMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -390,7 +422,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_nuc_holder_left_frontMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -399,7 +430,6 @@ PROTO Wolfgang [
         rotation 0.000000 0.000000 1.000000 1.570800
         children [
           Wolfgang_battery_cageMesh {
-            transparency IS transparency
           }
         ]
       }
@@ -503,7 +533,6 @@ PROTO Wolfgang [
               rotation -0.577350 -0.577352 0.577350 2.094399
               children [
                 Wolfgang_sea_connectorMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -512,7 +541,6 @@ PROTO Wolfgang [
               rotation -0.577350 -0.577352 0.577350 2.094399
               children [
                 Wolfgang_sea_ninjaflexMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -521,7 +549,6 @@ PROTO Wolfgang [
               rotation 0.000000 1.000000 0.000000 0.000000
               children [
                 Wolfgang_shoulder_connectorMesh {
-                transparency IS transparency
                 }
               ]
             }
@@ -556,7 +583,6 @@ PROTO Wolfgang [
                     rotation -1.000000 0.000000 -0.000000 1.570800
                     children [
                       Wolfgang_mx-64-bodyMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -565,7 +591,6 @@ PROTO Wolfgang [
                     rotation -0.577350 -0.577350 -0.577352 2.094399
                     children [
                       Wolfgang_upper_armMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -582,7 +607,6 @@ PROTO Wolfgang [
                           %{else}%
                             baseColor  0.0, 0.0, 0.0
                           %{ end }%
-                          transparency IS transparency
                         }
                         geometry Box {
                           size 0.07 0.005 0.04
@@ -595,7 +619,6 @@ PROTO Wolfgang [
                     rotation -0.577350 -0.577352 0.577350 2.094399
                     children [
                       Wolfgang_connector_shoulderMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -604,7 +627,6 @@ PROTO Wolfgang [
                     rotation -0.577350 0.577350 0.577352 2.094399
                     children [
                       Wolfgang_upper_armMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -613,7 +635,6 @@ PROTO Wolfgang [
                     rotation 0.577350 0.577352 0.577350 2.094399
                     children [
                       Wolfgang_connector_shoulderMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -622,7 +643,6 @@ PROTO Wolfgang [
                     rotation -0.000000 -1.000000 -0.000000 1.570800
                     children [
                       Wolfgang_upper_arm_spacerMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -658,7 +678,6 @@ PROTO Wolfgang [
                           rotation -0.000001 0.707108 -0.707105 3.141591
                           children [
                             Wolfgang_lower_armMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -667,7 +686,6 @@ PROTO Wolfgang [
                           rotation -1.000000 0.000000 0.000000 1.570800
                           children [
                             Wolfgang_mx-64-bodyMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -676,7 +694,6 @@ PROTO Wolfgang [
                           rotation 1.000000 0.000000 -0.000000 1.570800
                           children [
                             Wolfgang_handMesh {
-                            transparency IS transparency
                             }
                           ]
                         }
@@ -685,7 +702,6 @@ PROTO Wolfgang [
                           rotation -0.000001 0.707108 -0.707105 3.141591
                           children [
                             Wolfgang_lower_armMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1071,7 +1087,6 @@ PROTO Wolfgang [
               rotation 0.577350 -0.577352 -0.577350 2.094399
               children [
                 Wolfgang_sea_connectorMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -1080,7 +1095,6 @@ PROTO Wolfgang [
               rotation 0.000000 1.000000 0.000000 0.000000
               children [
                 Wolfgang_shoulder_connectorMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -1089,7 +1103,6 @@ PROTO Wolfgang [
               rotation 0.577350 -0.577352 -0.577350 2.094399
               children [
                 Wolfgang_sea_ninjaflexMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -1124,7 +1137,6 @@ PROTO Wolfgang [
                     rotation -1.000000 -0.000000 -0.000000 1.570800
                     children [
                       Wolfgang_mx-64-bodyMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1141,7 +1153,6 @@ PROTO Wolfgang [
                           %{else}%
                             baseColor  0.0, 0.0, 0.0
                           %{ end }%
-                          transparency IS transparency
                         }
                         geometry Box {
                           size 0.07 0.005 0.04
@@ -1155,7 +1166,6 @@ PROTO Wolfgang [
                     rotation -0.577350 -0.577352 0.577350 2.094399
                     children [
                       Wolfgang_connector_shoulderMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1164,7 +1174,6 @@ PROTO Wolfgang [
                     rotation 0.577350 0.577352 0.577350 2.094399
                     children [
                       Wolfgang_connector_shoulderMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1173,7 +1182,6 @@ PROTO Wolfgang [
                     rotation 0.000000 -1.000000 0.000000 1.570800
                     children [
                       Wolfgang_upper_arm_spacerMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1182,7 +1190,6 @@ PROTO Wolfgang [
                     rotation -0.577350 0.577350 0.577352 2.094399
                     children [
                       Wolfgang_upper_armMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1191,7 +1198,6 @@ PROTO Wolfgang [
                     rotation -0.577350 -0.577350 -0.577352 2.094399
                     children [
                       Wolfgang_upper_armMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1227,7 +1233,6 @@ PROTO Wolfgang [
                           rotation -1.000000 -0.000000 0.000000 1.570800
                           children [
                             Wolfgang_mx-64-bodyMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1236,7 +1241,6 @@ PROTO Wolfgang [
                           rotation 1.000000 0.000000 0.000000 1.570800
                           children [
                             Wolfgang_lower_armMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1245,7 +1249,6 @@ PROTO Wolfgang [
                           rotation -0.000001 0.707108 -0.707105 3.141591
                           children [
                             Wolfgang_handMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1254,7 +1257,6 @@ PROTO Wolfgang [
                           rotation 1.000000 0.000000 0.000000 1.570800
                           children [
                             Wolfgang_lower_armMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1640,7 +1642,6 @@ PROTO Wolfgang [
               rotation 0.000000 1.000000 0.000000 0.000000
               children [
                 Wolfgang_hip_u_connectorMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -1676,7 +1677,6 @@ PROTO Wolfgang [
                     rotation -1.000000 0.000000 -0.000000 1.570800
                     children [
                       Wolfgang_mx-106_bodyMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1685,7 +1685,6 @@ PROTO Wolfgang [
                     rotation -0.707105 -0.707108 0.000001 3.141591
                     children [
                       Wolfgang_motor_connectorMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1694,7 +1693,6 @@ PROTO Wolfgang [
                     rotation 0.000000 -0.000000 -1.000000 3.141590
                     children [
                       Wolfgang_thrustbearingholderMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1703,7 +1701,6 @@ PROTO Wolfgang [
                     rotation -0.707105 0.707108 -0.000001 3.141591
                     children [
                       Wolfgang_motor_connectorMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1712,7 +1709,6 @@ PROTO Wolfgang [
                     rotation -0.577350 -0.577350 -0.577352 2.094399
                     children [
                       Wolfgang_mx-106_bodyMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -1749,7 +1745,6 @@ PROTO Wolfgang [
                           rotation 0.186156 -0.694748 0.694745 2.773490
                           children [
                             Wolfgang_knee_connectorMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1758,7 +1753,6 @@ PROTO Wolfgang [
                           rotation 0.000000 1.000000 0.000000 0.000000
                           children [
                             Wolfgang_upper_legMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1767,7 +1761,6 @@ PROTO Wolfgang [
                           rotation 0.186156 -0.694748 0.694745 2.773490
                           children [
                             Wolfgang_part_1Mesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1776,7 +1769,6 @@ PROTO Wolfgang [
                           rotation 0.186156 -0.694748 0.694745 2.773490
                           children [
                             Wolfgang_xh-540Mesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1785,7 +1777,6 @@ PROTO Wolfgang [
                           rotation 1.000000 -0.000000 0.000000 1.570800
                           children [
                             Wolfgang_spring_holder_upperMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1794,7 +1785,6 @@ PROTO Wolfgang [
                           rotation 0.186156 -0.694748 0.694745 2.773490
                           children [
                             Wolfgang_part_1Mesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1803,7 +1793,6 @@ PROTO Wolfgang [
                           rotation 0.000000 1.000000 0.000000 0.000000
                           children [
                             Wolfgang_upper_legMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1812,7 +1801,6 @@ PROTO Wolfgang [
                           rotation -0.935113 0.250562 0.250563 1.637837
                           children [
                             Wolfgang_knee_connectorMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1821,7 +1809,6 @@ PROTO Wolfgang [
                           rotation -0.092690 0.704064 0.704061 2.956736
                           children [
                             Wolfgang_upper_leg_spacerMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -1857,7 +1844,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_knee_spacerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1866,7 +1852,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_lower_legMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1875,7 +1860,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_lower_legMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1884,7 +1868,6 @@ PROTO Wolfgang [
                                 rotation -0.543774 0.593428 0.593425 2.145487
                                 children [
                                   Wolfgang_lower_leg_spacerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1893,7 +1876,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_springholder_newMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1902,7 +1884,6 @@ PROTO Wolfgang [
                                 rotation 0.000001 1.000000 0.000001 3.316126
                                 children [
                                   Wolfgang_spring_holder_lowerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1911,7 +1892,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_knee_spacerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1920,7 +1900,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_springholder_bottomMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -1957,7 +1936,6 @@ PROTO Wolfgang [
                                       rotation 0.577350 0.577352 0.577350 2.094399
                                       children [
                                         Wolfgang_motor_connectorMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -1966,7 +1944,6 @@ PROTO Wolfgang [
                                       rotation -0.577350 -0.577350 -0.577352 2.094399
                                       children [
                                         Wolfgang_mx-106_bodyMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -1975,7 +1952,6 @@ PROTO Wolfgang [
                                       rotation -0.577350 0.577352 -0.577350 2.094399
                                       children [
                                         Wolfgang_motor_connectorMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -1984,7 +1960,6 @@ PROTO Wolfgang [
                                       rotation 0.707105 0.000001 -0.707108 3.141591
                                       children [
                                         Wolfgang_thrustbearingholderMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -1993,7 +1968,6 @@ PROTO Wolfgang [
                                       rotation -1.000000 -0.000000 0.000000 1.570800
                                       children [
                                         Wolfgang_mx-106_bodyMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -2029,7 +2003,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2038,7 +2011,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_ankleMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2047,7 +2019,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2056,7 +2027,6 @@ PROTO Wolfgang [
                                             rotation 1.000000 0.000000 -0.000000 3.141590
                                             children [
                                               Wolfgang_forcefoot_pcbMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2065,7 +2035,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2074,7 +2043,6 @@ PROTO Wolfgang [
                                             rotation -0.000000 -0.000000 -1.000000 1.570800
                                             children [
                                               Wolfgang_foot_printed_rightMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2083,7 +2051,6 @@ PROTO Wolfgang [
                                             rotation -0.000000 -0.000000 1.000000 3.141590
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2092,7 +2059,6 @@ PROTO Wolfgang [
                                             rotation -0.000000 -0.000000 -1.000000 1.570800
                                             children [
                                               Wolfgang_foot_coverMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -2121,7 +2087,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -2171,7 +2136,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -2212,7 +2176,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -2253,7 +2216,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -3124,7 +3086,6 @@ PROTO Wolfgang [
               rotation 0.000000 1.000000 0.000000 0.000000
               children [
                 Wolfgang_hip_u_connectorMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -3160,7 +3121,6 @@ PROTO Wolfgang [
                     rotation -0.707105 0.707108 -0.000001 3.141591
                     children [
                       Wolfgang_motor_connectorMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -3169,7 +3129,6 @@ PROTO Wolfgang [
                     rotation -1.000000 -0.000000 0.000000 1.570800
                     children [
                       Wolfgang_mx-106_bodyMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -3178,7 +3137,6 @@ PROTO Wolfgang [
                     rotation -0.577350 0.577350 0.577352 2.094399
                     children [
                       Wolfgang_mx-106_bodyMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -3187,7 +3145,6 @@ PROTO Wolfgang [
                     rotation 0.707105 0.707108 0.000001 3.141591
                     children [
                       Wolfgang_motor_connectorMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -3196,7 +3153,6 @@ PROTO Wolfgang [
                     rotation 0.000000 0.000000 -1.000000 3.141590
                     children [
                       Wolfgang_thrustbearingholderMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -3233,7 +3189,6 @@ PROTO Wolfgang [
                           rotation 0.965926 0.258819 0.000000 3.141590
                           children [
                             Wolfgang_knee_connectorMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3242,7 +3197,6 @@ PROTO Wolfgang [
                           rotation -1.000000 0.000000 -0.000000 3.141590
                           children [
                             Wolfgang_part_1Mesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3251,7 +3205,6 @@ PROTO Wolfgang [
                           rotation 0.000000 -0.000000 -1.000000 2.617990
                           children [
                             Wolfgang_knee_connectorMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3260,7 +3213,6 @@ PROTO Wolfgang [
                           rotation -0.000000 -0.000000 -1.000000 2.617990
                           children [
                             Wolfgang_xh-540Mesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3269,7 +3221,6 @@ PROTO Wolfgang [
                           rotation -0.000000 -0.000000 1.000000 2.617990
                           children [
                             Wolfgang_spring_holder_upperMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3278,7 +3229,6 @@ PROTO Wolfgang [
                           rotation 0.000000 1.000000 0.000000 0.000000
                           children [
                             Wolfgang_part_1Mesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3287,7 +3237,6 @@ PROTO Wolfgang [
                           rotation 0.000001 -0.707108 -0.707105 3.141591
                           children [
                             Wolfgang_upper_legMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3296,7 +3245,6 @@ PROTO Wolfgang [
                           rotation 0.000001 0.707108 0.707105 3.141591
                           children [
                             Wolfgang_upper_legMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3305,7 +3253,6 @@ PROTO Wolfgang [
                           rotation -0.000000 -0.000000 -1.000000 0.261799
                           children [
                             Wolfgang_upper_leg_spacerMesh {
-                              transparency IS transparency
                             }
                           ]
                         }
@@ -3341,7 +3288,6 @@ PROTO Wolfgang [
                                 rotation 1.000000 -0.000000 0.000000 3.141590
                                 children [
                                   Wolfgang_springholder_newMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3350,7 +3296,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 -0.000000 -1.000000 3.141590
                                 children [
                                   Wolfgang_spring_holder_lowerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3359,7 +3304,6 @@ PROTO Wolfgang [
                                 rotation -1.000000 0.000000 0.000000 3.141590
                                 children [
                                   Wolfgang_springholder_bottomMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3368,7 +3312,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_knee_spacerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3377,7 +3320,6 @@ PROTO Wolfgang [
                                 rotation -0.543774 0.593428 0.593425 2.145487
                                 children [
                                   Wolfgang_lower_leg_spacerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3386,7 +3328,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_knee_spacerMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3395,7 +3336,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_lower_legMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3404,7 +3344,6 @@ PROTO Wolfgang [
                                 rotation 0.000000 1.000000 0.000000 0.000000
                                 children [
                                   Wolfgang_lower_legMesh {
-                                    transparency IS transparency
                                   }
                                 ]
                               }
@@ -3441,7 +3380,6 @@ PROTO Wolfgang [
                                       rotation 0.577350 -0.577352 -0.577350 2.094399
                                       children [
                                         Wolfgang_motor_connectorMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -3450,7 +3388,6 @@ PROTO Wolfgang [
                                       rotation -0.707105 -0.000001 -0.707108 3.141591
                                       children [
                                         Wolfgang_thrustbearingholderMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -3459,7 +3396,6 @@ PROTO Wolfgang [
                                       rotation -0.577350 -0.577352 0.577350 2.094399
                                       children [
                                         Wolfgang_motor_connectorMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -3468,7 +3404,6 @@ PROTO Wolfgang [
                                       rotation -1.000000 -0.000000 -0.000000 1.570800
                                       children [
                                         Wolfgang_mx-106_bodyMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -3477,7 +3412,6 @@ PROTO Wolfgang [
                                       rotation -0.577350 0.577350 0.577352 2.094399
                                       children [
                                         Wolfgang_mx-106_bodyMesh {
-                                          transparency IS transparency
                                         }
                                       ]
                                     }
@@ -3513,7 +3447,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3522,7 +3455,6 @@ PROTO Wolfgang [
                                             rotation -0.000000 0.000000 1.000000 3.141590
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3531,7 +3463,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 0.000000 -1.000000 1.570800
                                             children [
                                               Wolfgang_foot_printed_leftMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3540,7 +3471,6 @@ PROTO Wolfgang [
                                             rotation 1.000000 -0.000000 0.000000 3.141590
                                             children [
                                               Wolfgang_forcefoot_pcbMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3549,7 +3479,6 @@ PROTO Wolfgang [
                                             rotation -0.000000 -0.000000 -1.000000 1.570800
                                             children [
                                               Wolfgang_foot_coverMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3558,7 +3487,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_ankleMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3567,7 +3495,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3576,7 +3503,6 @@ PROTO Wolfgang [
                                             rotation 0.000000 1.000000 0.000000 0.000000
                                             children [
                                               Wolfgang_load_cellMesh {
-                                                transparency IS transparency
                                               }
                                             ]
                                           }
@@ -3605,7 +3531,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -3646,7 +3571,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -3687,7 +3611,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -3728,7 +3651,6 @@ PROTO Wolfgang [
                                                 rotation 0.000000 1.000000 0.000000 3.141592653589793
                                                 children [
                                                   Wolfgang_flex_stollenMesh {
-                                                    transparency IS transparency
                                                   }
                                                 ]
                                               }
@@ -4602,7 +4524,6 @@ PROTO Wolfgang [
               rotation 0.000000 1.000000 0.000000 0.000000
               children [
                 Wolfgang_connector_shoulderMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -4611,7 +4532,6 @@ PROTO Wolfgang [
               rotation 0.707105 -0.000001 0.707108 3.141591
               children [
                 Wolfgang_mx-64-bodyMesh {
-                  transparency IS transparency
                 }
               ]
             }
@@ -4647,7 +4567,6 @@ PROTO Wolfgang [
                     rotation -0.577350 -0.577350 -0.577352 2.094399
                     children [
                       Wolfgang_lenseMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -4656,7 +4575,6 @@ PROTO Wolfgang [
                     rotation 0.000000 1.000000 0.000000 0.000000
                     children [
                       Wolfgang_sea_ninjaflexMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -4665,7 +4583,6 @@ PROTO Wolfgang [
                     rotation 0.000000 -0.000000 1.000000 3.141590
                     children [
                       Wolfgang_sea_connectorMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -4674,7 +4591,6 @@ PROTO Wolfgang [
                     rotation 0.000000 1.000000 0.000000 0.000000
                     children [
                       Wolfgang_camera_side_basler_wolfgang_v2_2_rightMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -4683,7 +4599,6 @@ PROTO Wolfgang [
                     rotation 0.000000 1.000000 0.000000 0.000000
                     children [
                       Wolfgang_camera_side_basler_wolfgang_v2_2_leftMesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -4692,7 +4607,6 @@ PROTO Wolfgang [
                     rotation -0.577350 -0.577350 -0.577352 2.094399
                     children [
                       Wolfgang_basler_ace_gige_c-mount_v01Mesh {
-                        transparency IS transparency
                       }
                     ]
                   }
@@ -4701,7 +4615,6 @@ PROTO Wolfgang [
                     rotation 0.000000 -1.000000 0.000000 1.570800
                     children [
                       Wolfgang_camera_lower_basler_wolfgang_imu_v2_2Mesh {
-                        transparency IS transparency
                       }
                     ]
                   }

--- a/wolfgang_webots_sim/protos/WolfgangRobocup.proto
+++ b/wolfgang_webots_sim/protos/WolfgangRobocup.proto
@@ -2,7 +2,7 @@
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # This is a proto file for Webots for the WolfgangRobocup
-
+EXTERNPROTO "Wolfgang.proto"
 PROTO WolfgangRobocup [
   field  SFVec3f     translation     0 0 0
   field  SFRotation  rotation        0 1 0 0

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_ankleMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_ankleMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_ankleMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF ankle IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_baseplate_odroid_xu4_coreMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_baseplate_odroid_xu4_coreMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_baseplate_odroid_xu4_coreMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF baseplate_odroid_xu4_core IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_basler_ace_gige_c-mount_v01Mesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_basler_ace_gige_c-mount_v01Mesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangMetal.proto"
+
 PROTO Wolfgang_basler_ace_gige_c-mount_v01Mesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangMetal {transparency IS transparency}
+    appearance WolfgangMetal {}
     geometry DEF basler_ace_gige_c-mount_v01 IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_batteryMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_batteryMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_batteryMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF battery IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_battery_cageMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_battery_cageMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_battery_cageMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF battery_cage IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_battery_cage_holderMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_battery_cage_holderMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_battery_cage_holderMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF battery_cage_holder IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_battery_clipMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_battery_clipMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_battery_clipMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF battery_clip IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_camera_lower_basler_wolfgang_imu_v2_2Mesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_camera_lower_basler_wolfgang_imu_v2_2Mesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_camera_lower_basler_wolfgang_imu_v2_2Mesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF camera_lower_basler_wolfgang_imu_v2_2 IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_camera_side_basler_wolfgang_v2_2_leftMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_camera_side_basler_wolfgang_v2_2_leftMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_camera_side_basler_wolfgang_v2_2_leftMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF camera_side_basler_wolfgang_v2_2_left IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_camera_side_basler_wolfgang_v2_2_rightMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_camera_side_basler_wolfgang_v2_2_rightMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_camera_side_basler_wolfgang_v2_2_rightMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF camera_side_basler_wolfgang_v2_2_right IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_connector_shoulderMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_connector_shoulderMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_connector_shoulderMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF connector_shoulder IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_coreMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_coreMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/appearances/protos/Pcb.proto"
+
 PROTO Wolfgang_coreMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance Pcb {}
     geometry DEF core IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_dummy_speakerMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_dummy_speakerMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_dummy_speakerMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF dummy_speaker IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_flex_stollenMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_flex_stollenMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_flex_stollenMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF flex_stollen IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_foot_coverMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_foot_coverMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_foot_coverMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF foot_cover IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_foot_printed_leftMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_foot_printed_leftMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_foot_printed_leftMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF foot_printed_left IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_foot_printed_rightMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_foot_printed_rightMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_foot_printed_rightMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF foot_printed_right IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_forcefoot_pcbMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_forcefoot_pcbMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_forcefoot_pcbMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF forcefoot_pcb IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_handMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_handMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_handMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF hand IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_hip_u_connectorMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_hip_u_connectorMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_hip_u_connectorMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF hip_u_connector IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_imu_bottom_coverMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_imu_bottom_coverMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_imu_bottom_coverMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF imu_bottom_cover IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_imu_holderMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_imu_holderMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_imu_holderMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF imu_holder IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_knee_connectorMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_knee_connectorMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_knee_connectorMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF knee_connector IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_knee_spacerMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_knee_spacerMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_knee_spacerMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF knee_spacer IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lenseMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lenseMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_lenseMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF lense IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_load_cellMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_load_cellMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_load_cellMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF load_cell IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lower_armMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lower_armMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangCarbonFiberAppearance.proto"
+
 PROTO Wolfgang_lower_armMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangCarbonFiberAppearance {transparency IS transparency}
+    appearance WolfgangCarbonFiberAppearance {}
     geometry DEF lower_arm IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lower_legMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lower_legMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangCarbonFiberAppearance.proto"
+
 PROTO Wolfgang_lower_legMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangCarbonFiberAppearance {transparency IS transparency}
+    appearance WolfgangCarbonFiberAppearance {}
     geometry DEF lower_leg IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lower_leg_spacerMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_lower_leg_spacerMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_lower_leg_spacerMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF lower_leg_spacer IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_motor_connectorMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_motor_connectorMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_motor_connectorMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF motor_connector IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_mx-106_bodyMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_mx-106_bodyMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangMotor.proto"
+
 PROTO Wolfgang_mx-106_bodyMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangMotor {transparency IS transparency}
+    appearance WolfgangMotor {}
     geometry DEF mx-106_body IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_mx-64-bodyMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_mx-64-bodyMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangMotor.proto"
+
 PROTO Wolfgang_mx-64-bodyMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangMotor {transparency IS transparency}
+    appearance WolfgangMotor {}
     geometry DEF mx-64-body IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_bottomMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_bottomMesh.proto
@@ -1,11 +1,10 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
 PROTO Wolfgang_nuc_bottomMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
@@ -15,7 +14,6 @@ PROTO Wolfgang_nuc_bottomMesh [
       roughness 1.000000
       metalness 0
       emissiveColor 0.000000 0.000000 0.000000
-      transparency IS transparency
     }
     geometry DEF nuc_bottom IndexedFaceSet {
       coord Coordinate {

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_frontMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_frontMesh.proto
@@ -1,11 +1,10 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
 PROTO Wolfgang_nuc_frontMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
@@ -15,7 +14,6 @@ PROTO Wolfgang_nuc_frontMesh [
       roughness 1.000000
       metalness 0
       emissiveColor 0.000000 0.000000 0.000000
-      transparency IS transparency
     }
     geometry DEF nuc_front IndexedFaceSet {
       coord Coordinate {

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_left_backMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_left_backMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_nuc_holder_left_backMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF nuc_holder_left_back IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_left_frontMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_left_frontMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_nuc_holder_left_frontMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF nuc_holder_left_front IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_right_backMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_right_backMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_nuc_holder_right_backMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF nuc_holder_right_back IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_right_frontMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_holder_right_frontMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_nuc_holder_right_frontMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF nuc_holder_right_front IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_mainMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_nuc_mainMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangNUC.proto"
+
 PROTO Wolfgang_nuc_mainMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangNUC {transparency IS transparency}
+    appearance WolfgangNUC {}
     geometry DEF nuc_main IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_part_1Mesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_part_1Mesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_part_1Mesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF part_1 IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_power_regulatorMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_power_regulatorMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_power_regulatorMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF power_regulator IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_router_holder_leftMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_router_holder_leftMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_router_holder_leftMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF router_holder_left IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_router_holder_rightMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_router_holder_rightMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_router_holder_rightMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF router_holder_right IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_sea_connectorMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_sea_connectorMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_sea_connectorMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF sea_connector IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_sea_ninjaflexMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_sea_ninjaflexMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_sea_ninjaflexMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF sea_ninjaflex IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_shoulder_connectorMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_shoulder_connectorMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_shoulder_connectorMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF shoulder_connector IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_speaker_holderMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_speaker_holderMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_speaker_holderMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF speaker_holder IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_spring_holder_lowerMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_spring_holder_lowerMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_spring_holder_lowerMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF spring_holder_lower IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_spring_holder_upperMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_spring_holder_upperMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_spring_holder_upperMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF spring_holder_upper IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_springholder_bottomMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_springholder_bottomMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_springholder_bottomMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF springholder_bottom IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_springholder_newMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_springholder_newMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_springholder_newMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF springholder_new IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_switch_holderMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_switch_holderMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_switch_holderMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF switch_holder IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_thrustbearingholderMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_thrustbearingholderMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_thrustbearingholderMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF thrustbearingholder IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_bottomMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_bottomMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_torso_bottomMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF torso_bottom IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_bumper_leftMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_bumper_leftMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_torso_bumper_leftMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF torso_bumper_left IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_bumper_rightMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_bumper_rightMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_torso_bumper_rightMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF torso_bumper_right IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_topMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_torso_topMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPaintedMetal.proto"
+
 PROTO Wolfgang_torso_topMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPaintedMetal {transparency IS transparency}
+    appearance WolfgangPaintedMetal {}
     geometry DEF torso_top IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_armMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_armMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangCarbonFiberAppearance.proto"
+
 PROTO Wolfgang_upper_armMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangCarbonFiberAppearance {transparency IS transparency}
+    appearance WolfgangCarbonFiberAppearance {}
     geometry DEF upper_arm IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_arm_spacerMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_arm_spacerMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_upper_arm_spacerMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF upper_arm_spacer IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_legMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_legMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangCarbonFiberAppearance.proto"
+
 PROTO Wolfgang_upper_legMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangCarbonFiberAppearance {transparency IS transparency}
+    appearance WolfgangCarbonFiberAppearance {}
     geometry DEF upper_leg IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_leg_spacerMesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_upper_leg_spacerMesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangPlastic.proto"
+
 PROTO Wolfgang_upper_leg_spacerMesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangPlastic {transparency IS transparency}
+    appearance WolfgangPlastic {}
     geometry DEF upper_leg_spacer IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_xh-540Mesh.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_meshes/Wolfgang_xh-540Mesh.proto
@@ -1,15 +1,16 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
 # license: Apache License 2.0
 # license url: http://www.apache.org/licenses/LICENSE-2.0
 # tags: hidden
 # Extracted from: wolfgang.urdf
 
+EXTERNPROTO "../Wolfgang_textures/WolfgangMotor.proto"
+
 PROTO Wolfgang_xh-540Mesh [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
   Shape {
-    appearance WolfgangMotor {transparency IS transparency}
+    appearance WolfgangMotor {}
     geometry DEF xh-540 IndexedFaceSet {
       coord Coordinate {
         point [

--- a/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangMarker.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangMarker.proto
@@ -1,4 +1,4 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
     # license: Apache License 2.0
     # license url: http://www.apache.org/licenses/LICENSE-2.0
     # tags: hidden
@@ -7,7 +7,6 @@
     PROTO WolfgangMarker [
     field MFString textureUrl "Wolfgang_textures/number_0.png"
     field SFColor  baseColor   0.0 0.0 0.0
-    field SFFloat  transparency 0 # [0, 1]
     ]
 {
 PBRAppearance {
@@ -17,6 +16,5 @@ PBRAppearance {
     baseColorMap ImageTexture {
         url IS textureUrl
     }
-    transparency IS transparency
 }
 }

--- a/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangMetal.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangMetal.proto
@@ -1,11 +1,10 @@
- #VRML_SIM R2021b utf8
+ #VRML_SIM R2022b utf8
  # license: Apache License 2.0
  # license url: http://www.apache.org/licenses/LICENSE-2.0
  # tags: hidden
  # Extracted from: wolfgang.urdf
 
 PROTO WolfgangMetal [
-  field SFFloat  transparency 0 # [0, 1]
 ]
 {
     PBRAppearance {
@@ -14,6 +13,5 @@ PROTO WolfgangMetal [
        roughness 0.4
        metalness 1
        emissiveColor 0.000000 0.000000 0.000000
-      transparency IS transparency
      }
 }

--- a/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangMotor.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangMotor.proto
@@ -1,17 +1,15 @@
- #VRML_SIM R2021b utf8
+ #VRML_SIM R2022b utf8
  # license: Apache License 2.0
  # license url: http://www.apache.org/licenses/LICENSE-2.0
  # tags: hidden
  # Extracted from: wolfgang.urdf
 
 PROTO WolfgangMotor [
-  field SFFloat  transparency 0 # [0, 1]
 ]
 {
     PBRAppearance {
         baseColor 0.1 0.1 0.1
         roughness 1
         metalness 0
-        transparency IS transparency
     }
 }

--- a/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangNUC.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangNUC.proto
@@ -1,17 +1,15 @@
- #VRML_SIM R2021b utf8
+ #VRML_SIM R2022b utf8
  # license: Apache License 2.0
  # license url: http://www.apache.org/licenses/LICENSE-2.0
  # tags: hidden
  # Extracted from: wolfgang.urdf
 
 PROTO WolfgangNUC [
-  field SFFloat  transparency 0 # [0, 1]
 ]
 {
     PBRAppearance {
         baseColor 0.03 0.03 0.03
         roughness 0.8
         metalness 1
-        transparency IS transparency
     }
 }

--- a/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangOdroid.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangOdroid.proto
@@ -1,11 +1,10 @@
- #VRML_SIM R2021b utf8
+ #VRML_SIM R2022b utf8
  # license: Apache License 2.0
  # license url: http://www.apache.org/licenses/LICENSE-2.0
  # tags: hidden
  # Extracted from: wolfgang.urdf
 
 PROTO WolfgangOdroid [
-      field SFFloat  transparency 0 # [0, 1]
 ]
 {
     PBRAppearance {
@@ -14,6 +13,5 @@ PROTO WolfgangOdroid [
       roughness 1.000000
       metalness 0
       emissiveColor 0.000000 0.000000 0.000000
-      transparency IS transparency
     }
 }

--- a/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangPaintedMetal.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangPaintedMetal.proto
@@ -1,17 +1,15 @@
- #VRML_SIM R2021b utf8
+ #VRML_SIM R2022b utf8
  # license: Apache License 2.0
  # license url: http://www.apache.org/licenses/LICENSE-2.0
  # tags: hidden
  # Extracted from: wolfgang.urdf
 
 PROTO WolfgangPaintedMetal [
-  field SFFloat  transparency 0 # [0, 1]
 ]
 {
     PBRAppearance {
         baseColor 0.05 0.05 0.05
         roughness 0.6
         metalness 1
-        transparency IS transparency
     }
 }

--- a/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangPlastic.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang_textures/WolfgangPlastic.proto
@@ -1,17 +1,15 @@
- #VRML_SIM R2021b utf8
+ #VRML_SIM R2022b utf8
  # license: Apache License 2.0
  # license url: http://www.apache.org/licenses/LICENSE-2.0
  # tags: hidden
  # Extracted from: wolfgang.urdf
 
 PROTO WolfgangPlastic [
-    field SFFloat  transparency 0 # [0, 1]
 ]
 {
     PBRAppearance {
         baseColor 0.03 0.03 0.03
         roughness 0.8
         metalness 0
-        transparency IS transparency
     }
 }

--- a/wolfgang_webots_sim/scripts/start_simulator.py
+++ b/wolfgang_webots_sim/scripts/start_simulator.py
@@ -1,23 +1,17 @@
 #!/usr/bin/env python3
-import os
 import subprocess
 import threading
 
-import psutil
 import argparse
-import time
 
-import rcl_interfaces.msg
 import rclpy
 from ament_index_python import get_package_share_directory
-from rcl_interfaces.msg import Parameter, ParameterValue, ParameterType
 from rclpy.node import Node
-from rcl_interfaces.srv import SetParameters
 
 
 class WebotsSim(Node):
 
-    def __init__(self, nogui, multi_robot, headless, sim_id, robot_type):
+    def __init__(self, nogui, multi_robot, headless, sim_port, robot_type):
         super().__init__('webots_sim')
         pkg_path = get_package_share_directory("wolfgang_webots_sim")
 
@@ -48,41 +42,9 @@ class WebotsSim(Node):
             cmd = ["webots"]
 
         # actually start webots
-        cmd_with_args = cmd + list(extra_args) + [f"--mode={mode}", "--port=6009", f"{pkg_path}/worlds/{world_name}"]
+        cmd_with_args = cmd + list(extra_args) + [f"--mode={mode}", f"--port={sim_port}", f"{pkg_path}/worlds/{world_name}"]
         print(f"running {' '.join(cmd_with_args)}")
         self.sim_proc = subprocess.Popen(cmd_with_args)
-
-        # figure out webots pid
-        if headless:
-            webots_pid = None
-            child_procs = psutil.Process(self.sim_proc.pid).children()
-            while webots_pid is None:
-                time.sleep(0.0001)
-                assert self.sim_proc.poll() is None, "xvfb-run has exited"
-                child_procs = psutil.Process(self.sim_proc.pid).children(recursive=True)
-
-                # webots actually gets started with /bin/bash <path-to-webots>/webots <args> so we have to find that
-                for child_proc in child_procs:
-                    exec_file = os.path.basename(child_proc.exe())
-                    if exec_file == "bash":
-                        first_arg = os.path.basename(child_proc.cmdline()[1])
-                        if first_arg == "webots":
-                            webots_pid = child_proc.pid
-                            break
-        else:
-            webots_pid = self.sim_proc.pid
-
-        # set webots pid on rosparam server
-        print(f"webots_pid is {webots_pid}")
-        self.declare_parameter("/webots_pid", int(webots_pid))
-        blackboard_client = self.create_client(SetParameters, '/parameter_blackboard/set_parameters')
-        while not blackboard_client.wait_for_service(timeout_sec=1.0):
-            self.get_logger().info('blackboard not available, waiting again...')
-        req = SetParameters.Request()
-        parameter = ParameterValue(type=ParameterType.PARAMETER_INTEGER, integer_value=int(webots_pid))
-        req.parameters = [Parameter(name="webots_pid" + sim_id, value=parameter)]
-        future = blackboard_client.call_async(req)
-        rclpy.spin_until_future_complete(self, future)
 
     def run_simulation(self):
         # join with child process
@@ -99,13 +61,13 @@ if __name__ == "__main__":
                        help='Starts webots completely headless on a virtual framebuffer. This also automatically enables --batch and --no-rendering for webots',
                        action='store_true')
     group.add_argument('--nogui', help="Deactivate gui", action='store_true')
-    parser.add_argument('--sim_id', help="identifier of the simulation", default="")
+    parser.add_argument('--sim-port', help="port of the simulation", default="1234")
     parser.add_argument('--multi-robot', help="start world with a single robot", action='store_true')
     parser.add_argument('--robot-type', help="which robot should be started", default="wolfgang")
     args, _ = parser.parse_known_args()
 
     rclpy.init()
-    node = WebotsSim(args.nogui, args.multi_robot, args.headless, args.sim_id, args.robot_type)
+    node = WebotsSim(args.nogui, args.multi_robot, args.headless, args.sim_port, args.robot_type)
     thread = threading.Thread(target=rclpy.spin, args=(node,), daemon=True)
     thread.start()
     node.run_simulation()

--- a/wolfgang_webots_sim/scripts/start_simulator.py
+++ b/wolfgang_webots_sim/scripts/start_simulator.py
@@ -48,7 +48,7 @@ class WebotsSim(Node):
             cmd = ["webots"]
 
         # actually start webots
-        cmd_with_args = cmd + list(extra_args) + [f"--mode={mode}", f"{pkg_path}/worlds/{world_name}"]
+        cmd_with_args = cmd + list(extra_args) + [f"--mode={mode}", "--port=6009", f"{pkg_path}/worlds/{world_name}"]
         print(f"running {' '.join(cmd_with_args)}")
         self.sim_proc = subprocess.Popen(cmd_with_args)
 

--- a/wolfgang_webots_sim/scripts/start_single.py
+++ b/wolfgang_webots_sim/scripts/start_single.py
@@ -4,34 +4,17 @@ import os
 import threading
 
 import rclpy
-from rcl_interfaces.srv import GetParameters
 from rclpy.node import Node
-import time
 from wolfgang_webots_sim.webots_robot_controller import RobotController
 from controller import Robot
 
 
 class RobotNode:
-    def __init__(self, pid_param_name, robot_name, void_controller, disable_camera, recognize, robot_type):
+    def __init__(self, simulator_port, robot_name, void_controller, disable_camera, recognize, robot_type):
         self.node = Node('robot_node')
         self.void_controller = void_controller
 
-        blackboard_client = self.node.create_client(GetParameters, '/parameter_blackboard/get_parameters')
-        while not blackboard_client.wait_for_service(timeout_sec=3.0):
-            self.node.get_logger().info('blackboard not available, waiting again...')
-        req = GetParameters.Request(names=[pid_param_name])
-        while True:
-            future = blackboard_client.call_async(req)
-            rclpy.spin_until_future_complete(self.node, future)
-            if future.result() is not None:
-                break
-            else:
-                self.node.get_logger().info("Waiting for parameter " + pid_param_name + " to be set..")
-                time.sleep(2.0)
-        webots_pid = future.result().values[0]
-
-        #os.environ["WEBOTS_PID"] = str(webots_pid)
-        os.environ["WEBOTS_CONTROLLER_URL"] = f"ipc://6009/{robot_name}"
+        os.environ["WEBOTS_CONTROLLER_URL"] = f"ipc://{simulator_port}/{robot_name}"
 
         if void_controller:
             self.node.get_logger().info("Starting void interface for " + robot_name)
@@ -52,7 +35,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--robot_name', help="which robot should be started", default="amy")
     parser.add_argument('--robot-type', help="which robot should be started", default="wolfgang")
-    parser.add_argument('--sim_id', help="identifier of the simulation", default="")
+    parser.add_argument('--sim-port', help="port of the simulation", default="1234")
     parser.add_argument('--void-controller', action='store_true',
                         help="if true, a controller that only steps and does nothing else")
     parser.add_argument('--disable-camera', action='store_true',
@@ -60,10 +43,9 @@ if __name__ == "__main__":
     parser.add_argument('--recognize', action='store_true',
                         help="if true, recognition is active (for training data collection)")
     args, unknown = parser.parse_known_args()
-    pid_param_name = "webots_pid" + args.sim_id
 
     rclpy.init()
-    robot = RobotNode(pid_param_name, args.robot_name, args.void_controller, args.disable_camera, args.recognize, args.robot_type)
+    robot = RobotNode(args.sim_port, args.robot_name, args.void_controller, args.disable_camera, args.recognize, args.robot_type)
     thread = threading.Thread(target=rclpy.spin, args=(robot.node,), daemon=True)
     thread.start()
     robot.run()

--- a/wolfgang_webots_sim/scripts/start_single.py
+++ b/wolfgang_webots_sim/scripts/start_single.py
@@ -30,8 +30,8 @@ class RobotNode:
                 time.sleep(2.0)
         webots_pid = future.result().values[0]
 
-        os.environ["WEBOTS_PID"] = str(webots_pid)
-        os.environ["WEBOTS_ROBOT_NAME"] = robot_name
+        #os.environ["WEBOTS_PID"] = str(webots_pid)
+        os.environ["WEBOTS_CONTROLLER_URL"] = f"ipc://6009/{robot_name}"
 
         if void_controller:
             self.node.get_logger().info("Starting void interface for " + robot_name)

--- a/wolfgang_webots_sim/scripts/start_webots_ros_supervisor.py
+++ b/wolfgang_webots_sim/scripts/start_webots_ros_supervisor.py
@@ -27,8 +27,8 @@ class SupervisorNode:
                 time.sleep(2.0)
         webots_pid = future.result().values[0]
 
-        os.environ["WEBOTS_PID"] = str(webots_pid)
-        os.environ["WEBOTS_ROBOT_NAME"] = "supervisor_robot"
+        #os.environ["WEBOTS_PID"] = str(webots_pid)
+        os.environ["WEBOTS_CONTROLLER_URL"] = f"ipc://6009/supervisor_robot"
 
         self.supervisor_controller = SupervisorController(ros_active=True, ros_node=self.node)
         self.node.get_logger().info("started webots ros supervisor")

--- a/wolfgang_webots_sim/worlds/1_bot.wbt
+++ b/wolfgang_webots_sim/worlds/1_bot.wbt
@@ -1,7 +1,14 @@
-#VRML_SIM R2021b utf8
+#VRML_SIM R2022b utf8
+
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/objects/balls/protos/RobocupSoccerBall.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/samples/contests/robocup/protos/RobocupSoccerField.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/objects/backgrounds/protos/TexturedBackground.proto"
+EXTERNPROTO "https://raw.githubusercontent.com/cyberbotics/webots/R2022b/projects/objects/backgrounds/protos/TexturedBackgroundLight.proto"
+EXTERNPROTO "../protos/Wolfgang.proto"
+EXTERNPROTO "../protos/hl_supervisor/hl_supervisor.proto"
+
 DEF world_info WorldInfo {
   basicTimeStep 8
-  optimalThreadCount 1
   physicsDisableTime 0.1
   physicsDisableLinearThreshold 0.1
   physicsDisableAngularThreshold 0.1
@@ -29,8 +36,8 @@ DEF world_info WorldInfo {
   ]
 }
 Viewpoint {
-  orientation 0.2635181128215983 -0.36420919162686427 -0.8932580080522365 1.9916995318039916
-  position -9.204890354327318 3.450845837104254 7.847404655784381
+  orientation 0.13074775069234934 0.15392461377846517 -0.9793938119888453 1.674637090314644
+  position 0.0918799331514291 15.742602735510587 6.669799372347793
 }
 TexturedBackground {
   texture "stadium_dry"


### PR DESCRIPTION
## Proposed changes
- Switch to inter process communication between Webots and the controller

## Open topics
1. Now that the PID acces to the simulator is removed, we need to use an explicit port for it (to use ipc). For our tests we hardcoded `6009`, but we need to come up with a strategy how these ports are allocated when using multiple simulators. Any ideas?
2. Currently the old world and model are loaded, which leads to a broken collision model and camera. @jgueldenstein we tried your branch at the TC repo, but had errors, maybe you can have a look at it.
3. We currently only tested the `simulator.launch` with one robot. I have therefore no idea how reinforcment learning and parameter optimization stuff is affected.