### PR TITLE
Use bio_ik instead of the KDL default for all move groups

### DIFF
--- a/wolfgang_moveit_config/config/kinematics.yaml
+++ b/wolfgang_moveit_config/config/kinematics.yaml
@@ -7,6 +7,7 @@ RightLeg:
   kinematics_solver_search_resolution: 0.00001
   kinematics_solver_timeout: 0.01
 Legs:
+  kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 0.0001
   kinematics_solver_timeout: 0.005
 RightArm:
@@ -18,6 +19,7 @@ LeftArm:
   kinematics_solver_search_resolution: 0.00001
   kinematics_solver_timeout: 0.01
 Arms:
+  kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 0.00001
   kinematics_solver_timeout: 0.01
 Head:
@@ -25,5 +27,6 @@ Head:
   kinematics_solver_search_resolution: 0.001
   kinematics_solver_timeout: 0.001
 All:
+  kinematics_solver: bio_ik/BioIKKinematicsPlugin
   kinematics_solver_search_resolution: 0.005
   kinematics_solver_timeout: 0.005


### PR DESCRIPTION
## Proposed changes
- Change moveit config to use bio_ik all the time.

## Related issues
Closes https://github.com/bit-bots/bitbots_motion/issues/373
