### PR TITLE
Add tagged solids to wolfgang proto

### DIFF
--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -135,6 +135,10 @@ PROTO Wolfgang [
       Group {
         children IS externalCamera
       }
+      DEF base_link Transform {
+        translation 0.0 0.0 0.0
+        rotation 0.0 0.0 0.0 0.0
+      }
       Transform {
         translation -0.001500 0.053000 0.203500
         rotation -0.707105 0.000001 0.707108 3.141591
@@ -709,6 +713,12 @@ PROTO Wolfgang [
                           translation 0.000000 -0.226182 -0.023500
                           rotation 0.577350 -0.577352 -0.577350 2.094399
                           name "r_wrist [hand]"
+                          children [
+                            DEF r_gripper Transform {
+                              translation 0.0 0.0 0.0
+                              rotation 0.0 0.0 0.0 0.0
+                            }
+                          ]
                         }
                       ]
                       name "r_lower_arm [arm]"
@@ -1264,6 +1274,12 @@ PROTO Wolfgang [
                           translation -0.000000 -0.225182 -0.023500
                           rotation -0.577350 0.577352 -0.577350 2.094399
                           name "l_wrist [hand]"
+                          children [
+                            DEF l_gripper Transform {
+                              translation 0.0 0.0 0.0
+                              rotation 0.0 0.0 0.0 0.0
+                            }
+                          ]
                         }
                       ]
                       name "l_lower_arm [arm]"
@@ -4633,6 +4649,10 @@ PROTO Wolfgang [
                         fieldOfView IS cameraFOV
                         width IS cameraWidth
                         height IS cameraHeight
+                      }
+                      DEF camera_frame Transform {
+                        translation 0.0 0.0 0.0
+                        rotation 0.0 0.0 0.0 0.0
                       }
                     ]
                     name "camera_optical_frame"

--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -135,10 +135,7 @@ PROTO Wolfgang [
       Group {
         children IS externalCamera
       }
-      DEF base_link Transform {
-        translation 0.0 0.0 0.0
-        rotation 0.0 0.0 0.0 0.0
-      }
+      DEF base_link Transform {}
       Transform {
         translation -0.001500 0.053000 0.203500
         rotation -0.707105 0.000001 0.707108 3.141591
@@ -714,10 +711,7 @@ PROTO Wolfgang [
                           rotation 0.577350 -0.577352 -0.577350 2.094399
                           name "r_wrist [hand]"
                           children [
-                            DEF r_gripper Transform {
-                              translation 0.0 0.0 0.0
-                              rotation 0.0 0.0 0.0 0.0
-                            }
+                            DEF r_gripper Transform {}
                           ]
                         }
                       ]
@@ -1275,10 +1269,7 @@ PROTO Wolfgang [
                           rotation -0.577350 0.577352 -0.577350 2.094399
                           name "l_wrist [hand]"
                           children [
-                            DEF l_gripper Transform {
-                              translation 0.0 0.0 0.0
-                              rotation 0.0 0.0 0.0 0.0
-                            }
+                            DEF l_gripper Transform {}
                           ]
                         }
                       ]
@@ -4650,10 +4641,7 @@ PROTO Wolfgang [
                         width IS cameraWidth
                         height IS cameraHeight
                       }
-                      DEF camera_frame Transform {
-                        translation 0.0 0.0 0.0
-                        rotation 0.0 0.0 0.0 0.0
-                      }
+                      DEF camera_frame Transform {}
                     ]
                     name "camera_optical_frame"
                   }

--- a/wolfgang_webots_sim/protos/Wolfgang.proto
+++ b/wolfgang_webots_sim/protos/Wolfgang.proto
@@ -4632,10 +4632,10 @@ PROTO Wolfgang [
                   }
                   DEF camera_optical_frame Solid {
                     translation 0.043200 0.080000 -0.023500
-                    rotation -0.000001 0.707105 -0.707108 3.141591
+                    rotation 0.7071068 0.0 0.7071068 3.1415927
                     children [
                       Camera {
-                        rotation 0.0 1.0 0.0 3.141591
+                        rotation 0.5773503 -0.5773503 0.5773503 2.0943951
                         name "camera"
                         fieldOfView IS cameraFOV
                         width IS cameraWidth


### PR DESCRIPTION
## Proposed changes
Add tagged solids to wolfgang proto to comply with HLVS specifications:
https://humanoid.robocup.org/wp-content/uploads/v-hsc_model_specification.pdf