### PR TITLE
Fix docker build with updated requirements file

### DIFF
--- a/wolfgang_robocup_api/docker/Dockerfile
+++ b/wolfgang_robocup_api/docker/Dockerfile
@@ -24,7 +24,8 @@ RUN apt install -y libjsoncpp-dev build-essential git sudo python3-pip python3-r
     python3-protobuf espeak ros-rolling-xacro ros-rolling-cv-bridge ros-rolling-moveit-ros-robot-interaction \
     ros-rolling-control-toolbox libprotobuf-dev protobuf-compiler libprotoc-dev ros-rolling-topic-tools \
     python3-psutil python3-hypothesis ros-rolling-ament-cmake-nose ros-rolling-rot-conv ros-rolling-moveit-planners-ompl \
-    ros-rolling-camera-info-manager ros-rolling-image-geometry ros-rolling-soccer-vision-3d-msgs && \
+    ros-rolling-camera-info-manager ros-rolling-image-geometry ros-rolling-soccer-vision-3d-msgs \
+    python3-transforms3d python3-sklearn python3-numpy ros-rolling-tf-transformations python3-construct && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -58,7 +59,8 @@ RUN . /opt/ros/rolling/setup.sh && \
 ADD --chown=robot:robot https://raw.githubusercontent.com/bit-bots/bitbots_meta/master/requirements.txt src/requirements.txt
 
 RUN sed -i -e /pydot/d -e /silx/d -e /pyopencl/d src/requirements.txt && \
-    pip3 install -U -r src/requirements.txt --no-cache-dir
+    pip3 install -U -r src/requirements.txt --no-cache-dir && \
+    pip3 uninstall -y numpy
 
 RUN cd src && \
     git clone https://github.com/Bit-Bots/bitbots_meta.git && \


### PR DESCRIPTION
## Proposed changes
The additional packages are no longer in the requirements file but are installed via rosdep. However, I don't want to use rosdep in the container because it will install some packages that are not needed and makes caching impossible.
Also, the installation of numpy via pip has to be removed because a breaking change has not been addressed in all packages we use.

## Related issues
bit-bots/bitbots_meta#168 makes the change necessary.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

