### PR TITLE
Docker: remove tts pip deps

### DIFF
--- a/wolfgang_robocup_api/docker/Dockerfile
+++ b/wolfgang_robocup_api/docker/Dockerfile
@@ -58,7 +58,7 @@ RUN . /opt/ros/rolling/setup.sh && \
 
 ADD --chown=robot:robot https://raw.githubusercontent.com/bit-bots/bitbots_meta/master/requirements.txt src/requirements.txt
 
-RUN sed -i -e /pydot/d -e /silx/d -e /pyopencl/d src/requirements.txt && \
+RUN sed -i -e /mycroft-mimic3-tts/d -e /pydot/d -e /pyopencl/d -e /pyttsx3/d src/requirements.txt && \
     pip3 install -U -r src/requirements.txt --no-cache-dir && \
     pip3 uninstall -y numpy
 


### PR DESCRIPTION
## Proposed changes
- Removes the following dependencies from the `requirements.txt` before installing:
    - `mycroft-mimic3-tts`
    - `pyttsx3`
- Removing `silx` is not necessary anymore, as it is currently not included in the `requirements.txt` file.

## Related issues
bit-bots/bitbots_meta/pull/173

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

