### PR TITLE
Port setenvs.sh script to a launch file

### DIFF
--- a/wolfgang_webots_sim/CMakeLists.txt
+++ b/wolfgang_webots_sim/CMakeLists.txt
@@ -58,7 +58,6 @@ install(PROGRAMS
   scripts/fix_urdf_for_webots.py
   scripts/imu_lut_gen.py
   scripts/localization_faker.py
-  scripts/setenvs.sh
   scripts/start_simulator.py
   scripts/start_single.py
   scripts/start_webots_ros_supervisor.py

--- a/wolfgang_webots_sim/launch/simulation.launch
+++ b/wolfgang_webots_sim/launch/simulation.launch
@@ -15,6 +15,12 @@
     <let name="gui_flag" value="$(eval '\'\' if \'$(var gui)\'==\'true\' else \'--nogui\'')"/>
     <let name="headless_flag" value="$(eval '\'--headless\' if \'$(var headless)\'==\'true\' else \'\'')"/>
 
+    <!-- source nessessary files for webots -->
+    <set_env name="WEBOTS_HOME" value="$(env WEBOTS_HOME /usr/local/webots)"/>
+    <set_env name="LD_LIBRARY_PATH" value="$(env LD_LIBRARY_PATH):$(env WEBOTS_HOME)/lib/controller"/>
+    <!-- Change the python version here if you want to use a different version of python -->
+    <set_env name="PYTHONPATH" value="$(env PYTHONPATH):$(env WEBOTS_HOME)/lib/controller/python310"/>
+
     <!-- start simulation and supervisor either with or without gui -->
     <node pkg="wolfgang_webots_sim" exec="start_simulator.py" name="webots_sim"
           output="screen" args="$(var multi_robot_flag) $(var gui_flag) $(var headless_flag) --sim-port $(var sim_port) --robot-type $(var robot_type)"/>

--- a/wolfgang_webots_sim/scripts/setenvs.sh
+++ b/wolfgang_webots_sim/scripts/setenvs.sh
@@ -1,9 +1,0 @@
-#!/bin/zsh
-
-export WEBOTS_HOME=${WEBOTS_HOME:-/usr/local/webots}
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${WEBOTS_HOME}/lib/controller
-[[ -f /usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4 ]] && export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4
-[[ -d ${WEBOTS_HOME}/lib/controller/python36 ]] && export PYTHONPATH=$PYTHONPATH:${WEBOTS_HOME}/lib/controller/python36
-[[ -d ${WEBOTS_HOME}/lib/controller/python38 ]] && export PYTHONPATH=$PYTHONPATH:${WEBOTS_HOME}/lib/controller/python38
-[[ -d ${WEBOTS_HOME}/lib/controller/python310 ]] && export PYTHONPATH=$PYTHONPATH:${WEBOTS_HOME}/lib/controller/python310
-export PYTHONPATH=$PYTHONPATH:$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )


### PR DESCRIPTION
Removes the need for sourcing the `setenvs.sh` script before running the simulator (non-hlvs player). This reduces complexity.

## Proposed changes
- Set the appropriate env variables in the launch file
- Remove the old script

I tested this on my machine and it worked fine. I removed some lines were not needed imo., but I want to get a second opinion on this @timonegk.
