### PR TITLE
Fix: Add `rosbag2` dependency

### DIFF
--- a/wolfgang_robocup_api/package.xml
+++ b/wolfgang_robocup_api/package.xml
@@ -26,6 +26,7 @@
   <depend>protobuf-dev</depend>
   <depend>urdfdom_py</depend>
   <depend>topic_tools</depend>
+  <depend>rosbag2</depend>
 
   <export>
     <build_type>ament_python</build_type>


### PR DESCRIPTION
## Proposed changes
Add `rosbag2` dependency as it is needed to record rosbags using the CLI.

## Related issues
Needs also to be done in bit-bots/bitbots_misc/pull/190

## Necessary checks
- [X] Put the PR on our Project board

